### PR TITLE
fix: yes to all queries in apt-get install

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -120,12 +120,12 @@ runs:
     - name: "Install system dependencies"
       shell: bash
       run: |
-        sudo apt-get install ${{ env.NEEDED_DEPS }}
+        sudo apt-get install -y ${{ env.NEEDED_DEPS }}
 
     - name: "Install LaTeX"
       shell: bash
       run: |
-        sudo apt-get install texlive-latex-extra latexmk
+        sudo apt-get install -y texlive-latex-extra latexmk
 
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -147,7 +147,7 @@ runs:
       shell: bash
       if: inputs.decompress-artifact == 'true'
       run: |
-        sudo apt-get install cargo && cargo install ouch && ouch --version
+        sudo apt-get install -y cargo && cargo install ouch && ouch --version
         cd version/dev && compressed_artifact=$(ls .)
         ouch decompress $compressed_artifact && rm $compressed_artifact
 
@@ -172,7 +172,7 @@ runs:
       run: |
         if ! [[ -f "versions.json" ]];
         then
-            sudo apt-get install moreutils jq
+            sudo apt-get install -y moreutils jq
             echo '[]' > versions.json
             url_dev="https://${{ inputs.cname }}/version/dev/"
             jq --arg url $url_dev '. += [{"name": "dev", "version": "dev", "url": $url}]' versions.json | sponge versions.json

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -213,7 +213,7 @@ runs:
       shell: bash
       if: inputs.decompress-artifact == 'true'
       run: |
-        sudo apt-get install cargo && cargo install ouch && ouch --version
+        sudo apt-get install -y cargo && cargo install ouch && ouch --version
         cd version/${{ env.VERSION }} && compressed_artifact=$(ls .)
         ouch decompress $compressed_artifact && rm $compressed_artifact
 
@@ -235,7 +235,7 @@ runs:
     - name: "Install 'sponge' and 'jq' for manipulating JSON files"
       shell: bash
       run: |
-        sudo apt-get install moreutils jq
+        sudo apt-get install -y moreutils jq
 
     - name: "Create a clean 'versions.json' file"
       shell: bash

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -91,7 +91,7 @@ runs:
       if: inputs.requires-xvfb == 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install xvfb
+        sudo apt-get install -y xvfb
 
     - name: "Check if requirements.txt file exists"
       shell: bash


### PR DESCRIPTION
Includes the `-y` flag when performing an `apt-get install` to ensure that the CI/CD process does not hang or die because the lack of user input.