### PR TITLE
fix: ensure cargo binaries are in PATH

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -147,7 +147,9 @@ runs:
       shell: bash
       if: inputs.decompress-artifact == 'true'
       run: |
-        sudo apt-get install -y cargo && cargo install ouch && ouch --version
+        sudo apt-get install -y cargo && cargo install ouch
+        export PATH="$HOME/.cargo/bin/:$PATH"
+        ouch --version
         cd version/dev && compressed_artifact=$(ls .)
         ouch decompress $compressed_artifact && rm $compressed_artifact
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -213,7 +213,9 @@ runs:
       shell: bash
       if: inputs.decompress-artifact == 'true'
       run: |
-        sudo apt-get install -y cargo && cargo install ouch && ouch --version
+        sudo apt-get install -y cargo && cargo install ouch
+        export PATH="$HOME/.cargo/bin/:$PATH"
+        ouch --version
         cd version/${{ env.VERSION }} && compressed_artifact=$(ls .)
         ouch decompress $compressed_artifact && rm $compressed_artifact
 


### PR DESCRIPTION
This pull-request ensures that all binaries installed by `cargo` get added to the path of the current shell session.

That's the default situation with cargo. However, we have experienced some issues so let us make it explicit its addition to the path.