### PR TITLE
feat: Adding option for repository when cleaning packages

### DIFF
--- a/hk-package-clean-except/action.yml
+++ b/hk-package-clean-except/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: false
     default: 'ansys'
     type: string
+  repository:
+    description: "Repository at which packages are published."
+    required: false
+    default: ''
+    type: string
   allow-last-days:
     description: "Avoid removing the last N days images: e.g. '2'."
     required: false
@@ -62,6 +67,7 @@ runs:
         PACKAGE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
         org_str = "${{ inputs.package-org }}"
+        repo_str = "${{ inputs.repository }}"
         pck_str = "${{ inputs.package-name }}"
         last_days_str = "${{ inputs.allow-last-days }}"
         valid_tags_str = "${{ inputs.tags-kept }}"
@@ -69,7 +75,7 @@ runs:
         last_days = int(last_days_str) if last_days_str != "" else None
         valid_tags = [x.strip() for x in valid_tags_str.split(",")]
 
-        api = GhApi(debug=print_summary, token=os.getenv("PACKAGE_DELETION_TOKEN"))
+        api = GhApi(debug=print_summary, repo=repo_str, token=os.getenv("PACKAGE_DELETION_TOKEN"))
 
         if last_days:
             delete_before_date = datetime.now() - timedelta(days=last_days)

--- a/hk-package-clean-untagged/action.yml
+++ b/hk-package-clean-untagged/action.yml
@@ -15,6 +15,11 @@ inputs:
     required: false
     default: 'ansys'
     type: string
+  repository:
+    description: "Repository at which packages are published."
+    required: false
+    default: ''
+    type: string
   allow-last-days:
     description: "Avoid removing the last N days images: e.g. '2'."
     required: false
@@ -58,6 +63,7 @@ runs:
         PACKAGE_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
         org_str = "${{ inputs.package-org }}"
+        repo_str = "${{ inputs.repository }}"
         pck_str = "${{ inputs.package-name }}"
         last_days_str = "${{ inputs.allow-last-days }}"
 
@@ -65,7 +71,7 @@ runs:
         if last_days:
             delete_before_date = datetime.now() - timedelta(days=last_days)
 
-        api = GhApi(debug=print_summary, token=os.getenv("PACKAGE_DELETION_TOKEN"))
+        api = GhApi(debug=print_summary, repo=repo_str, token=os.getenv("PACKAGE_DELETION_TOKEN"))
 
         paged_packages = paged(
             api.packages.get_all_package_versions_for_package_owned_by_org,


### PR DESCRIPTION
Currently you cannot clean packages under a repository. Only if they belong to the organization.
This is fine, but it is a bit limiting when we have packages like [pymapdl/mapdl](https://github.com/ansys/pymapdl/pkgs/container/pymapdl%2Fmapdl) (At PyMAPDL we do things differently to everybody else it seems)

This PR adds the possibility to include the repo where you are cleaning the packages.

Based on:
https://github.com/fastai/ghapi/issues/84