### PR TITLE
fix: check proper import and version variable

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: "Verify library is properly installed and get its version number"
       shell: bash
       run: |
-        library_version=$(python -c "from ${{ inputs.library-namespace }} import __version__; print(__version__)" || exit 1 )
+        library_version=$(python -c "from ${{ inputs.library-namespace }} import __version__; print(); print(__version__)" | tail -1 || exit 1 )
         if [ -z "$library_version" ]; then
             echo "Problem getting the library version"
             exit 1;

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -89,7 +89,14 @@ runs:
     - name: "Verify library is properly installed and get its version number"
       shell: bash
       run: |
-        echo "library_version=$(python -c "from ${{ inputs.library-namespace }} import __version__; print(__version__)")" >> $GITHUB_ENV
+        library_version=$(python -c "from ${{ inputs.library-namespace }} import __version__; print(__version__)" || exit 1 )
+        if [ -z "$library_version" ]; then
+            echo "Problem getting the library version"
+            exit 1;
+        else
+            echo "The library version is: $library_version";
+        fi;
+        echo "$library_version" >> $GITHUB_ENV
 
     - name: "Generate the wheelhouse"
       shell: bash


### PR DESCRIPTION
Because of `$()` if there is an error while importing the library, the exception/error is hidden because it does not affect the parent process. 

With this PR, we check that the variable has ben properly created which means that the package can be imported properly.

Closes #275