### PR TITLE
feat: stop asking for library-namespace

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
       run: |
         library_name=${{ inputs.library-name }}
 
-        if [ ${{ env.needs_importlib_metadata }} ]; then 
+        if [ ${{ env.needs_importlib_metadata }} ]; then
           version=$(python -c "import importlib_metadata; print(importlib_metadata.version('$library_name'))")
         else
           version=$(python -c "import importlib.metadata as importlib_metadata; print(importlib_metadata.version('$library_name'))")

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -19,14 +19,6 @@ inputs:
     required: true
     type: string
 
-  library-namespace:
-    description: >
-      Namespace of the Python library. The namespace is the path used when
-      importing the library in Python. The library requires to have a
-      ``__version__`` variable at its top ``__init__.py`` file.
-    required: true
-    type: string
-
   operating-system:
     description: >
       Name of the operating system where the library is installed.
@@ -89,7 +81,8 @@ runs:
     - name: "Verify library is properly installed and get its version number"
       shell: bash
       run: |
-        version=$(python -c "from ${{ inputs.library-namespace }} import __version__; print(); print(__version__)" | tail -1 || exit 1 )
+        library_name=${{ inputs.library-name }}
+        version=$(python -c "import importlib.metadata as metadata; print(metadata.version('$library_name'))")
         if [ -z "$version" ]; then
             echo "Problem getting the library version"
             exit 1;

--- a/doc/source/build-actions/examples/build-wheelhouse-basic.yml
+++ b/doc/source/build-actions/examples/build-wheelhouse-basic.yml
@@ -10,6 +10,5 @@ build-wheelhouse:
       uses: ansys/actions/build-wheelhouse@{{ branch }}
       with:
         library-name: "<ansys-product-library>"
-        library-namespace: "<ansys.product.library>"
         operating-system: ${{ '{{ matrix.os }}' }}
         python-version: ${{ '{{ matrix.python-version }}' }}


### PR DESCRIPTION
Fix #280 by retrieving the library version from its name using the `importlib.metadata` module. Once this is merged, a deprecation should be added in @v4.0.