### PR TITLE
ci: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, the PyAnsys Core team will be requested for
+# review when someone opens a pull request.
+*       @ansys/pyansys-core


### PR DESCRIPTION
This pull-request adds the `CODEOWNERS` file to the repository to automatically ping any PyAnsys core team member when reviewing a pull-request.