### PR TITLE
feat: support poetry build system in tests

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -177,7 +177,7 @@ runs:
 
     - name: "Install test dependencies from pyproject.toml"
       shell: bash
-      if: env.EXISTS_TESTS_REQUIREMENTS == 'false'
+      if: env.EXISTS_DOC_REQUIREMENTS == 'false'
       run: |
         if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
           python -m pip install poetry

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -153,12 +153,6 @@ runs:
       shell: bash
       run: python -m pip install -U pip
 
-    - name: "Install Python library"
-      shell: bash
-      if: inputs.skip-install == 'false'
-      run:
-        python -m pip install .
-
     - name: "Check if requirements.txt file exists"
       shell: bash
       run: |
@@ -166,18 +160,31 @@ runs:
 
     - name: "Print previous output"
       shell: bash
-      run:
+      run: |
         echo "Output was found ${{ env.EXISTS_DOC_REQUIREMENTS }}"
 
     - name: "Install documentation dependencies from requirements file"
       shell: bash
       if: env.EXISTS_DOC_REQUIREMENTS == 'true'
-      run: python -m pip install -r requirements/requirements_doc.txt
+      run: |
+        python -m pip install -r requirements/requirements_doc.txt
 
-    - name: "Install documentation dependencies from pyproject.toml"
+    - name: "Install Python library"
       shell: bash
-      if: env.EXISTS_DOC_REQUIREMENTS == 'false'
-      run: python -m pip install .[doc]
+      if: inputs.skip-install == 'false'
+      run: |
+        python -m pip install .
+
+    - name: "Install test dependencies from pyproject.toml"
+      shell: bash
+      if: env.EXISTS_TESTS_REQUIREMENTS == 'false'
+      run: |
+        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          python -m pip install poetry
+          poetry install --with doc
+        else
+          python -m pip install .[doc]
+        fi
 
     - name: "Build HTML, PDF, and JSON documentation"
       if: inputs.requires-xvfb == 'false'

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -175,7 +175,7 @@ runs:
       run: |
         python -m pip install .
 
-    - name: "Install test dependencies from pyproject.toml"
+    - name: "Install documentation dependencies from pyproject.toml"
       shell: bash
       if: env.EXISTS_DOC_REQUIREMENTS == 'false'
       run: |

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -111,7 +111,13 @@ runs:
     - name: "Install test dependencies from pyproject.toml"
       shell: bash
       if: env.EXISTS_TESTS_REQUIREMENTS == 'false'
-      run: python -m pip install .[tests]
+      run: |
+        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          python -m pip install poetry
+          poetry install --with tests
+        else
+          python -m pip install .[tests]
+        fi
 
     - name: "Executing test suite without using xvfb"
       if: inputs.requires-xvfb == 'false'


### PR DESCRIPTION
Implements #270 by introducing support for ``poetry`` and ``setuptools`` for the following actions that install a project with some additional dependencies:

- ansys/actions/test-pytest
- ansys/actions/doc-build