### PR TITLE
docs: document allowed prefixes for branch name style action

### DIFF
--- a/branch-name-style/action.yml
+++ b/branch-name-style/action.yml
@@ -13,7 +13,7 @@ description: >
       - feat
       - junk
       - maint
-      - doc or docs
+      - docs
       - no-ci
       - testing or test
       - release

--- a/branch-name-style/action.yml
+++ b/branch-name-style/action.yml
@@ -35,7 +35,7 @@ runs:
         fi
 
         branch_prefix=$(echo "$branch_name" | cut -d '/' -f 1)
-        valid_prefixes=("fix" "feat" "junk" "maint" "doc" "docs" "no-ci" "test" "testing" "release" "dependabot")
+        valid_prefixes=("fix" "feat" "junk" "maint" "docs" "no-ci" "test" "testing" "release" "dependabot")
 
         if [[ ! ${valid_prefixes[@]} =~ $branch_prefix ]]; then
           echo "\033[1;91m[ERROR]: Branch name $branch_prefix prefix is not valid." >&2

--- a/branch-name-style/action.yml
+++ b/branch-name-style/action.yml
@@ -5,6 +5,20 @@ description: >
   Checks if the name of the branch follows the branch naming convention of
   PyAnsys.
 
+  .. note::
+
+      Branch names must start with one of the following prefixes:
+
+      - fix
+      - feat
+      - junk
+      - maint
+      - doc or docs
+      - no-ci
+      - testing or test
+      - release
+      - dependabot
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This pull-request documents in a `note` admonition the allowed branch name prefixes.