### PR TITLE
docs: add warning admonition

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -7,6 +7,11 @@ description: >
   This allows for local installations and avoids the need to connect to the
   online PyPI index.
 
+  .. warning::
+
+      Since version 4.1, the input parameter ``library-namespace`` is no longer
+      required.
+
 inputs:
 
   # Required inputs


### PR DESCRIPTION
Fixes #290 by introducing a warning in the documentation. Since we removed the ``library-name`` input parameter, it is no longer possible to reference it in the workflow. Thus, we can not check if the user just passed it. GitHub is the one taking care of this warning.