### PR TITLE
docs: fix multi-line docstring

### DIFF
--- a/branch-name-style/action.yml
+++ b/branch-name-style/action.yml
@@ -1,7 +1,7 @@
 name: >
   Branch name style
 
-description: >
+description: |
   Checks if the name of the branch follows the branch naming convention of
   PyAnsys.
 


### PR DESCRIPTION
Continuation of #301. Fixes the rendering of the multi-line docstrings in the description of the action.