### PR TITLE
fix: syntax errors

### DIFF
--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -294,6 +294,7 @@ runs:
           cname=${{ inputs.cname }}
           new_item="{ \"name\": \"Older versions\", \"version\": \"N/A\", \"url\": \"https://$cname/version/index.html\" }"
           jq ". + [$new_item]" versions.json > tmp.json && mv tmp.json versions.json
+        fi
 
     - name: "Convert the first stable version into the 'stable' one"
       shell: bash

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -290,7 +290,7 @@ runs:
       run: |
         num_versions=$(jq length versions.json)
 
-        if [ $num_elements -gt ${{ inputs.render-last }} ]; then
+        if [ $num_versions -gt ${{ inputs.render-last }} ]; then
           cname=${{ inputs.cname }}
           new_item="{ \"name\": \"Older versions\", \"version\": \"N/A\", \"url\": \"https://$cname/version/index.html\" }"
           jq ". + [$new_item]" versions.json > tmp.json && mv tmp.json versions.json


### PR DESCRIPTION
This pull-request introduces a syntax fix in the `doc-deploy-stable` action when limiting the number of versions displayed in the drop-down menu.