### PR TITLE
feat: adding ansys corba to ignored licenses

### DIFF
--- a/check-licenses/ignored-packages.txt
+++ b/check-licenses/ignored-packages.txt
@@ -7,3 +7,4 @@ reuse
 typing
 typing_extensions
 typing-extensions
+ansys-corba


### PR DESCRIPTION
The package [ansys-corba](https://github.com/ansys/pymapdl-corba) is currently archived (only-read) and it does not have a valid license (no license at all).

I think, we should add it to the exceptions. Or unarchive it and add a license. I don't mind either.

Reason for this PR:

https://github.com/ansys/pymapdl/actions/runs/5799747218/job/15720419673?pr=2234#step:2:3884


Pinging @jorgepiloto @RobPasMue 