### PR TITLE
fix: tag trigger in workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "*"
+      - "v*.*.*"
     branches:
       - main
 
@@ -240,6 +240,7 @@ jobs:
     - name: "Release to GitHub"
       uses: softprops/action-gh-release@v1
       with:
+        generate_release_notes: true
         files: |
           documentation-html.zip
           documentation-pdf.zip


### PR DESCRIPTION
Fixes the issues pointed out by @Revathyvenugopal162. This ensures that only for tags following `v*.*.*` the CI/CD pipelines get triggered:

- Fails because multi-version does not ingest `vX`, see https://github.com/ansys/actions/actions/runs/5795010942
- Generates draft PRs because some candidates were already released


