### PR TITLE
fix: sort ignored packages and add WMI

### DIFF
--- a/check-licenses/ignored-packages.txt
+++ b/check-licenses/ignored-packages.txt
@@ -1,3 +1,4 @@
+ansys-corba
 defusedxml
 filelock
 matplotlib
@@ -5,6 +6,6 @@ pypiwin32
 pywin32
 reuse
 typing
-typing_extensions
 typing-extensions
-ansys-corba
+typing_extensions
+WMI


### PR DESCRIPTION
This package is required by one of our libraries. This library is still under development. The WMI package is using an MIT, see https://pypi.org/project/WMI/. However, because it does not ship with a LICENSE file, it needs to be manually ignored.

```console
Invalid licenses found:

WMI 1.4.9 has http://www.opensource.org/licenses/mit-license.php license

 Name                                   Version   License                                            
 WMI                                    1.4.9     http://www.opensource.org/licenses/mit-license.php 
```                                          