### PR TITLE
fix: vale-action version (using docker)

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -44,12 +44,11 @@ runs:
 
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog
+      working-directory: doc
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
-        files: doc
         reporter: github-pr-check
         level: error
         filter_mode: nofilter
         fail_on_error: true
-        vale_flags: "--config=${{ inputs.vale-config }}"

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -47,7 +47,6 @@ runs:
       uses: errata-ai/vale-action@13d79669d1c7cf33b26fc5607214ef529f071cdc
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-        HOME: '/home/runner'
       with:
         files: doc
         reporter: github-pr-check

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -48,7 +48,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         HOME: '/home/runner'
       with:
-        files: ./doc
+        files: doc
         reporter: github-pr-check
         level: error
         filter_mode: nofilter

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -43,6 +43,7 @@ runs:
       if: ${{ inputs.checkout == 'true' }}
 
     - name: "Run Vale"
+      # uses: errata-ai/vale-action@reviewdog # THIS SHOULD BE UNCOMMENTED EVENTUALLY
       uses: errata-ai/vale-action@13d79669d1c7cf33b26fc5607214ef529f071cdc
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -47,8 +47,9 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
-        working-directory: doc
+        files: ./doc
         reporter: github-pr-check
         level: error
         filter_mode: nofilter
         fail_on_error: true
+        vale_flags: "--config=${{ inputs.vale-config }}"

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -44,10 +44,10 @@ runs:
 
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog
-      working-directory: doc
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
+        working-directory: doc
         reporter: github-pr-check
         level: error
         filter_mode: nofilter

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -43,12 +43,11 @@ runs:
       if: ${{ inputs.checkout == 'true' }}
 
     - name: "Run Vale"
-      uses: errata-ai/vale-action@reviewdog
+      uses: errata-ai/vale-action@13d79669d1c7cf33b26fc5607214ef529f071cdc
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         HOME: '/home/runner'
       with:
-        version: 2.28.3
         files: ./doc
         reporter: github-pr-check
         level: error

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -48,6 +48,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
         HOME: '/home/runner'
       with:
+        version: 2.28.3
         files: ./doc
         reporter: github-pr-check
         level: error

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -46,6 +46,7 @@ runs:
       uses: errata-ai/vale-action@reviewdog
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+        HOME: '/home/runner'
       with:
         files: ./doc
         reporter: github-pr-check


### PR DESCRIPTION
vale-action removed support for building doker image for reviewdog, and this is causing some failures on our actions. Pinning down the version temporarily to the commit previous to deleting all this stuff.