### PR TITLE
fix: doc-build action - awalsh128/cache-apt-pkgs version

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -122,7 +122,7 @@ runs:
         fi
 
     - name: "Cache apt packages needed"
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@v1.3.0
       if: ${{ inputs.skip-dependencies-cache == 'false' }}
       with:
         packages: ${{ env.NEEDED_DEPS }}


### PR DESCRIPTION
Pin awalsh128/cache-apt-pkgs to version 1.3.0. 

v1.3.1 came out today and broke workflows that have requires-xvfb = false
- https://github.com/ansys/pydynamicreporting/actions/runs/6697205595/job/18200293938
- https://github.com/ansys/pre-commit-hooks/actions/runs/6697431280/job/18200960100#step:2:147



