### PR TITLE
chore: bump doc-style vale version (2.29.6)

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -31,7 +31,7 @@ inputs:
       Version number for Vale.
     # TODO: use the latest stable version from Vale, see issue
     # https://github.com/ansys/actions/issues/350
-    default: '2.29.3'
+    default: '2.29.6'
     required: false
     type: string
 


### PR DESCRIPTION
Multiple repos use the ansys/doc-style action without providing specific inputs. Since using "2.29.6" and updating accepts.txt file fixes the warning many developers faced, I would recommend "2.29.6" to be the default version used.