### PR TITLE
fix: Add openai to ignored licenses

### DIFF
--- a/check-licenses/ignored-packages.txt
+++ b/check-licenses/ignored-packages.txt
@@ -10,3 +10,4 @@ typing
 typing-extensions
 typing_extensions
 WMI
+openai


### PR DESCRIPTION
Add OpenAI Python library to ignored packages in the license checker, since it doesn't have the license properly configured in PyPI. It uses Apache license, so it should be fine.

References:
https://github.com/openai/openai-python
https://pypi.org/project/openai/