### PR TITLE
fix: locator in sitemap action

### DIFF
--- a/_doc-gen-sitemap/action.yml
+++ b/_doc-gen-sitemap/action.yml
@@ -65,7 +65,7 @@ runs:
             url="$input_dir${file%.html}"
           fi
           echo "  <url>" >> $output
-          echo "    <loc>$website$url</loc>" >> $output
+          echo "    <loc>$website/$url</loc>" >> $output
           echo "    <lastmod>$(date +%Y-%m-%dT%H:%M:%S+00:00)</lastmod>" >> $output
           echo "    <changefreq>weekly</changefreq>" >> $output
           echo "    <priority>0.5</priority>" >> $output


### PR DESCRIPTION
Fixes #375 by adding a `/` between the website URL and the page.