### PR TITLE
feat: add dockerfile linting

### DIFF
--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -29,7 +29,7 @@ inputs:
 
   docker-recursive:
     description: >
-      Search for Dockerfile(s) recursively. Only applies to directory 'docker'.
+      Search for Dockerfile(s) recursively. Only applies to allowed directories, i.e. docker and .devcontainer.
     required: false
     default: false
     type: bool

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -5,7 +5,8 @@ description: >
   This action evaluates the code quality of your project by using `pre-commit
   <https://github.com/pre-commit/pre-commit/>`_. The action installs and runs
   ``pre-commit``. It is assumed that your project contains a
-  ``.pre-commit-config.yaml`` file in the root directory.
+  ``.pre-commit-config.yaml`` file in the root directory. The action can also
+  be extended to lint docker files.
 
 inputs:
 
@@ -48,6 +49,13 @@ inputs:
     default: 2
     type: int
 
+  docker-directory:
+    description: >
+      Directory from which to search for Dockerfile(s).
+    required: false
+    default: docker
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -73,91 +81,29 @@ runs:
 
     # ------------------------------------------------------------------------
 
-    # The following steps are applying docker-style action to allowed working dirs if they exist.
-    # Changes performed should coherent with the 'allowed_working_dirs' in the docker-style action.
+    # Trigger docker-style action if docker-lint is set to true.
     - uses: ansys/actions/_logging@main
+      if: ${{ inputs.docker-lint == 'true' }}
       with:
         level: "INFO"
         message: >
-          Extend the workflow to lint Dockerfile(s) if option docker-lint is
-          set to true, exit otherwise.
-
-    - name: "Exit if docker-lint is false"
-      shell: bash
-      run: |
-        if [[ "${{ inputs.docker-lint }}" == "true" ]]; then
-          echo "RUN_DOCKER_LINT=true" >> $GITHUB_ENV
-        fi
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.RUN_DOCKER_LINT == 'true'
-      with:
-        level: "INFO"
-        message: >
-          Check that directory 'docker' exists at the root of the repository.
-          If it does not, then it means that the rest of the action should not
-          be performed.
-
-    - name: "Check if docker directory exists"
-      if: env.RUN_DOCKER_LINT == 'true'
-      shell: bash
-      run: |
-        if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "HAS_DOCKER_DIR=true" >> $GITHUB_ENV
-        else
-          echo "HAS_DOCKER_DIR=false" >> $GITHUB_ENV
-        fi
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
-      with:
-        level: "INFO"
-        message: >
-          Lint directory '${{ github.workspace }}/docker'.
+          Extend the workflow to lint Dockerfile(s) in
+          '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
-      if: env.HAS_DOCKER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
-      uses: ansys/actions/docker-style@main
+      if: ${{ inputs.docker-lint == 'true' }}
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
-        directory: docker
+        directory: ${{ inputs.docker-directory }}
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 
     # ------------------------------------------------------------------------
 
+    # End action as docker-lint is set to false.
     - uses: ansys/actions/_logging@main
-      if: env.RUN_DOCKER_LINT == 'true'
+      if: ${{ inputs.docker-lint == 'false' }}
       with:
         level: "INFO"
         message: >
-          Check if directory '.devcontainer' exists.
-
-    - name: "Check if .devcontainer directory exists"
-      if: env.RUN_DOCKER_LINT == 'true'
-      shell: bash
-      run: |
-        if [ -d "${{ github.workspace }}/.devcontainer" ]; then
-          echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_ENV
-        else
-          echo "HAS_DEVCONTAINER_DIR=false" >> $GITHUB_ENV
-        fi
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.HAS_DEVCONTAINER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
-      with:
-        level: "INFO"
-        message: >
-          Lint directory '${{ github.workspace }}/.devcontainer'.
-
-    - name: "Run Dockerfile linting in .devcontainer directory"
-      if: env.HAS_DEVCONTAINER_DIR == 'false' && env.RUN_DOCKER_LINT == 'true'
-      uses: ansys/actions/docker-style@main
-      with:
-        directory: .devcontainer
-        error-level: ${{ inputs.docker-error-level }}
+          Docker lint disabled.

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: "Run Dockerfile linting in directories 'docker' and '.devcontainer'"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@main
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: "docker .devcontainer"
         recursive: ${{ inputs.docker-recursive }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -85,7 +85,7 @@ runs:
     - name: "Exit if docker-lint is false"
       shell: bash
       run: |
-        if [ ${{ inputs.docker-lint }} == false ]; then
+        if [[ "${{ inputs.docker-lint }}" == "false" ]]; then
           exit 0
         fi
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -84,6 +84,7 @@ runs:
           be performed.
 
     - name: "Check if docker directory exists"
+      id: checkdocker
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
@@ -95,7 +96,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'false'
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
       with:
         level: "WARNING"
         message: >
@@ -105,22 +106,22 @@ runs:
           directory at the root of the repository.
 
     - name: "Exit workflow"
-      if: env.HAS_DOCKER_DIR == 'false'
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
       shell: bash
       run: exit 0
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'true'
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'true'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
-      if: env.HAS_DOCKER_DIR == 'true'
       with:
         directory: docker
         recursive: ${{ inputs.docker-recursive }}
@@ -136,6 +137,7 @@ runs:
 
     - name: "Check if .devcontainer directory exists"
       shell: bash
+      id: checkdevcontainer
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer" ]; then
           echo "HAS_DEVCONTAINER_DIR='true'" >> $GITHUB_OUTPUT
@@ -146,7 +148,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DEVCONTAINER_DIR == 'false'
+      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
       with:
         level: "INFO"
         message: >
@@ -154,22 +156,22 @@ runs:
           the repository.
 
     - name: "Exit workflow"
-      if: env.HAS_DEVCONTAINER_DIR == 'false'
+      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
       shell: bash
       run: exit 0
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DEVCONTAINER_DIR == 'true'
+      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in .devcontainer directory"
+      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
-      if: env.HAS_DEVCONTAINER_DIR == 'true'
       with:
         directory: .devcontainer
         error-level: ${{ inputs.docker-error-level }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -87,9 +87,9 @@ runs:
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR='true'" >> $GITHUB_OUTPUT
         else
-          echo "HAS_DOCKER_DIR=false" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR='false'" >> $GITHUB_OUTPUT
         fi
 
     # ------------------------------------------------------------------------
@@ -138,9 +138,9 @@ runs:
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer" ]; then
-          echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_OUTPUT
+          echo "HAS_DEVCONTAINER_DIR='true'" >> $GITHUB_OUTPUT
         else
-          echo "HAS_DEVCONTAINER_DIR=false" >> $GITHUB_OUTPUT
+          echo "HAS_DEVCONTAINER_DIR='false'" >> $GITHUB_OUTPUT
         fi
 
     # ------------------------------------------------------------------------

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -64,7 +64,7 @@ runs:
       shell: bash
       run: pre-commit run --all-files --show-diff-on-failure
 
-    # The followings steps are applying docker-style action to allowed working dirs if the exist.
+    # The following steps are applying docker-style action to allowed working dirs if they exist.
     # Changes performed here should coherent with the 'allowed_working_dirs' in the docker-style action.
     - name: "Check if docker directory exists"
       shell: bash
@@ -87,12 +87,12 @@ runs:
       id: checkdevcontainer
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer/Dockerfile" ]; then
-          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Run Dockerfile linting in .devcontainer directory"
       uses: ansys/actions/docker-style@main
-      if: steps.checkdevcontainer.outputs.exists == 'true'
+      if: env.HAS_DEVCONTAINER_DIR == 'true'
       with:
         directory: .devcontainer
         error-level: ${{ inputs.docker-error-level }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -91,7 +91,7 @@ runs:
           '${{ github.workspace }}/docker' and
           '${{ github.workspace }}/.devcontainer'.
 
-    - name: "Run Dockerfile linting in docker directory"
+    - name: "Run Dockerfile linting in 'docker' directory"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
@@ -99,7 +99,7 @@ runs:
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 
-    - name: "Run Dockerfile linting in docker directory"
+    - name: "Run Dockerfile linting in '.devcontainer' directory"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -6,8 +6,7 @@ description: >
   <https://github.com/pre-commit/pre-commit/>`_. The action installs and runs
   ``pre-commit``. It is assumed that your project contains a
   ``.pre-commit-config.yaml`` file in the root directory. The action can also
-  be extended to lint docker files that are contained in docker and
-  .devcontainer.
+  be extended to lint docker files that are contained in the docker directory and the .devcontainer directory.
 
     .. warning::
 
@@ -85,14 +84,14 @@ runs:
 
     # Trigger docker-style action if docker-lint is set to true.
     - uses: ansys/actions/_logging@main
-      if: ${{ inputs.docker-lint == 'true' }}
+      if: inputs.docker-lint == 'true'
       with:
         level: "INFO"
         message: >
           Extend the workflow to lint Dockerfile(s).
 
     - name: "Run Dockerfile linting in directories 'docker' and '.devcontainer'"
-      if: ${{ inputs.docker-lint == 'true' }}
+      if: inputs.docker-lint == 'true'
       uses: ansys/actions/docker-style@main
       with:
         directory: "docker .devcontainer"

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -27,6 +27,13 @@ inputs:
     default: true
     type: boolean
 
+  docker-lint:
+    description: >
+      Extend the workflow to lint Dockerfile(s).
+    required: false
+    default: false
+    type: bool
+
   docker-recursive:
     description: >
       Search for Dockerfile(s) recursively. Only applies to allowed directories, i.e. docker and .devcontainer.
@@ -64,15 +71,37 @@ runs:
       shell: bash
       run: pre-commit run --all-files --show-diff-on-failure
 
+    # ------------------------------------------------------------------------
+
     # The following steps are applying docker-style action to allowed working dirs if they exist.
-    # Changes performed here should coherent with the 'allowed_working_dirs' in the docker-style action.
+    # Changes performed should coherent with the 'allowed_working_dirs' in the docker-style action.
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Check that directory 'docker' exists at the root of the repository.
+          If it does not, then it means that the rest of the action should not
+          be performed.
+
     - name: "Check if docker directory exists"
       shell: bash
-      id: checkdocker
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
           echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
         fi
+
+    - name: "Exit workflow"
+      if: env.HAS_DOCKER_DIR == 'false'
+      shell: bash
+      run: exit 0
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Lint directory '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
       uses: ansys/actions/docker-style@main
@@ -82,11 +111,18 @@ runs:
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Check if directory '.devcontainer' exists.
+
     - name: "Check if .devcontainer directory exists"
       shell: bash
-      id: checkdevcontainer
       run: |
-        if [ -d "${{ github.workspace }}/.devcontainer/Dockerfile" ]; then
+        if [ -d "${{ github.workspace }}/.devcontainer" ]; then
           echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_OUTPUT
         fi
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -71,7 +71,7 @@ runs:
       id: checkdocker
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Run Dockerfile linting in docker directory"

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -91,7 +91,7 @@ runs:
         message: >
           Extend the workflow to lint Dockerfile(s).
 
-    - name: "Run Dockerfile linting"
+    - name: "Run Dockerfile linting in 'docker' directory"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@main
       with:

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -104,7 +104,7 @@ runs:
           Lint directory '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
-      uses: ansys/actions/docker-style@main
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       if: env.HAS_DOCKER_DIR == 'true'
       with:
         directory: docker
@@ -127,7 +127,7 @@ runs:
         fi
 
     - name: "Run Dockerfile linting in .devcontainer directory"
-      uses: ansys/actions/docker-style@main
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       if: env.HAS_DEVCONTAINER_DIR == 'true'
       with:
         directory: .devcontainer

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: "Run Dockerfile linting"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      uses: ansys/actions/docker-style@main
       with:
         directory: docker
         recursive: ${{ inputs.docker-recursive }}
@@ -101,7 +101,7 @@ runs:
 
     - name: "Run Dockerfile linting in '.devcontainer' directory"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      uses: ansys/actions/docker-style@main
       with:
         directory: .devcontainer
         recursive: ${{ inputs.docker-recursive }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -88,7 +88,21 @@ runs:
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
           echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
+        else
+          echo "HAS_DOCKER_DIR=false" >> $GITHUB_OUTPUT
         fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.HAS_DOCKER_DIR == 'false'
+      with:
+        level: "WARNING"
+        message: >
+          Exit action as no 'docker' directory exists at the root of the
+          repository. Except in special cases, e.g. '.devcontainer', we
+          emphasize that docker files are expected to be in the 'docker'
+          directory at the root of the repository.
 
     - name: "Exit workflow"
       if: env.HAS_DOCKER_DIR == 'false'
@@ -98,6 +112,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: env.HAS_DOCKER_DIR == 'true'
       with:
         level: "INFO"
         message: >
@@ -124,7 +139,33 @@ runs:
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer" ]; then
           echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_OUTPUT
+        else
+          echo "HAS_DEVCONTAINER_DIR=false" >> $GITHUB_OUTPUT
         fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.HAS_DEVCONTAINER_DIR == 'false'
+      with:
+        level: "INFO"
+        message: >
+          Exit action as no '.devcontainer' directory exists at the root of
+          the repository.
+
+    - name: "Exit workflow"
+      if: env.HAS_DEVCONTAINER_DIR == 'false'
+      shell: bash
+      run: exit 0
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.HAS_DEVCONTAINER_DIR == 'true'
+      with:
+        level: "INFO"
+        message: >
+          Lint directory '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in .devcontainer directory"
       uses: ansys/actions/docker-style@feat/lint_dockerfile

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -79,6 +79,24 @@ runs:
       with:
         level: "INFO"
         message: >
+          Extend the workflow to lint Dockerfile(s) if option docker-lint is
+          set to true, exit otherwise.
+
+    - name: "Check if docker directory exists"
+      shell: bash
+      run: |
+        if ${{ inputs.docker-lint }} == true ; then
+          exit 0
+        fi
+
+    # ------------------------------------------------------------------------
+
+    # The following steps are applying docker-style action to allowed working dirs if they exist.
+    # Changes performed should coherent with the 'allowed_working_dirs' in the docker-style action.
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
           Check that directory 'docker' exists at the root of the repository.
           If it does not, then it means that the rest of the action should not
           be performed.

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -44,14 +44,16 @@ inputs:
 
   docker-recursive:
     description: >
-      Search for Dockerfile(s) recursively. Only applies to allowed directories, i.e. docker and .devcontainer.
+      Search for Dockerfile(s) recursively. Only applies to allowed
+      directories, i.e. docker and .devcontainer.
     required: false
     default: false
     type: bool
 
   docker-error-level:
     description: >
-      Fail docker-style action based on hadolint output (-1: never, 0: error, 1: warning, 2: info)
+      Fail docker-style action based on hadolint output (-1: never, 0: error,
+      1: warning, 2: info)
     required: false
     default: 2
     type: int
@@ -87,11 +89,9 @@ runs:
       with:
         level: "INFO"
         message: >
-          Extend the workflow to lint Dockerfile(s) in
-          '${{ github.workspace }}/docker' and
-          '${{ github.workspace }}/.devcontainer'.
+          Extend the workflow to lint Dockerfile(s).
 
-    - name: "Run Dockerfile linting in 'docker' directory"
+    - name: "Run Dockerfile linting"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
@@ -99,13 +99,16 @@ runs:
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 
-    - name: "Run Dockerfile linting in '.devcontainer' directory"
-      if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
-      with:
-        directory: .devcontainer
-        recursive: ${{ inputs.docker-recursive }}
-        error-level: ${{ inputs.docker-error-level }}
+    # FIXME: Currently the action cannot work with multiple directory
+    # because of a bug, see
+    # https://github.com/jbergstroem/hadolint-gh-action/pull/135
+    # - name: "Run Dockerfile linting in '.devcontainer' directory"
+    #   if: ${{ inputs.docker-lint == 'true' }}
+    #   uses: ansys/actions/docker-style@feat/lint_dockerfile
+    #   with:
+    #     directory: .devcontainer
+    #     recursive: ${{ inputs.docker-recursive }}
+    #     error-level: ${{ inputs.docker-error-level }}
 
     # ------------------------------------------------------------------------
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -82,17 +82,15 @@ runs:
           Extend the workflow to lint Dockerfile(s) if option docker-lint is
           set to true, exit otherwise.
 
-    - name: "Check if docker directory exists"
+    - name: "Exit if docker-lint is false"
       shell: bash
       run: |
-        if ${{ inputs.docker-lint }} == true ; then
+        if ${{ inputs.docker-lint }} == false ; then
           exit 0
         fi
 
     # ------------------------------------------------------------------------
 
-    # The following steps are applying docker-style action to allowed working dirs if they exist.
-    # Changes performed should coherent with the 'allowed_working_dirs' in the docker-style action.
     - uses: ansys/actions/_logging@main
       with:
         level: "INFO"

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: "Run Dockerfile linting in 'docker' directory"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@main
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: docker
         recursive: ${{ inputs.docker-recursive }}
@@ -101,7 +101,7 @@ runs:
 
     - name: "Run Dockerfile linting in '.devcontainer' directory"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@main
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: .devcontainer
         recursive: ${{ inputs.docker-recursive }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -85,15 +85,14 @@ runs:
     - name: "Exit if docker-lint is false"
       shell: bash
       run: |
-        if [[ "${{ inputs.docker-lint }}" == "false" ]]; then
-          exit 0
-        else
-          echo "SOMETHIN STRANGE IS HAPPENING"
+        if [[ "${{ inputs.docker-lint }}" == "true" ]]; then
+          echo "RUN_DOCKER_LINT=true" >> $GITHUB_ENV
         fi
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: env.RUN_DOCKER_LINT == 'true'
       with:
         level: "INFO"
         message: >
@@ -102,6 +101,7 @@ runs:
           be performed.
 
     - name: "Check if docker directory exists"
+      if: env.RUN_DOCKER_LINT == 'true'
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
@@ -113,31 +113,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'false'
-      with:
-        level: "WARNING"
-        message: >
-          Exit action as no 'docker' directory exists at the root of the
-          repository. Except in special cases, e.g. '.devcontainer', we
-          emphasize that docker files are expected to be in the 'docker'
-          directory at the root of the repository.
-
-    - name: "Exit workflow"
-      if: env.HAS_DOCKER_DIR == 'false'
-      shell: bash
-      run: exit 0
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'true'
+      if: env.HAS_DOCKER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
-      if: env.HAS_DOCKER_DIR == 'true'
+      if: env.HAS_DOCKER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: docker
@@ -147,12 +130,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: env.RUN_DOCKER_LINT == 'true'
       with:
         level: "INFO"
         message: >
           Check if directory '.devcontainer' exists.
 
     - name: "Check if .devcontainer directory exists"
+      if: env.RUN_DOCKER_LINT == 'true'
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer" ]; then
@@ -164,29 +149,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DEVCONTAINER_DIR == 'false'
-      with:
-        level: "INFO"
-        message: >
-          Exit action as no '.devcontainer' directory exists at the root of
-          the repository.
-
-    - name: "Exit workflow"
-      if: env.HAS_DEVCONTAINER_DIR == 'false'
-      shell: bash
-      run: exit 0
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.HAS_DEVCONTAINER_DIR == 'true'
+      if: env.HAS_DEVCONTAINER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in .devcontainer directory"
-      if: env.HAS_DEVCONTAINER_DIR == 'false'
+      if: env.HAS_DEVCONTAINER_DIR == 'false' & env.RUN_DOCKER_LINT == 'true'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: .devcontainer

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -71,7 +71,7 @@ runs:
       id: checkdocker
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "::set-output name=exists::true"
+          echo "exists=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Run Dockerfile linting in docker directory"
@@ -87,7 +87,7 @@ runs:
       id: checkdevcontainer
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer/Dockerfile" ]; then
-          echo "::set-output name=exists::true"
+          echo "exists=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Run Dockerfile linting in .devcontainer directory"

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -84,19 +84,18 @@ runs:
           be performed.
 
     - name: "Check if docker directory exists"
-      id: checkdocker
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "HAS_DOCKER_DIR='true'" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR=true" >> $GITHUB_ENV
         else
-          echo "HAS_DOCKER_DIR='false'" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR=false" >> $GITHUB_ENV
         fi
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
+      if: env.HAS_DOCKER_DIR == 'false'
       with:
         level: "WARNING"
         message: >
@@ -106,21 +105,21 @@ runs:
           directory at the root of the repository.
 
     - name: "Exit workflow"
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
+      if: env.HAS_DOCKER_DIR == 'false'
       shell: bash
       run: exit 0
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'true'
+      if: env.HAS_DOCKER_DIR == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/docker'.
 
     - name: "Run Dockerfile linting in docker directory"
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'true'
+      if: env.HAS_DOCKER_DIR == 'true'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: docker
@@ -137,18 +136,17 @@ runs:
 
     - name: "Check if .devcontainer directory exists"
       shell: bash
-      id: checkdevcontainer
       run: |
         if [ -d "${{ github.workspace }}/.devcontainer" ]; then
-          echo "HAS_DEVCONTAINER_DIR='true'" >> $GITHUB_OUTPUT
+          echo "HAS_DEVCONTAINER_DIR=true" >> $GITHUB_ENV
         else
-          echo "HAS_DEVCONTAINER_DIR='false'" >> $GITHUB_OUTPUT
+          echo "HAS_DEVCONTAINER_DIR=false" >> $GITHUB_ENV
         fi
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
+      if: env.HAS_DEVCONTAINER_DIR == 'false'
       with:
         level: "INFO"
         message: >
@@ -156,21 +154,21 @@ runs:
           the repository.
 
     - name: "Exit workflow"
-      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
+      if: env.HAS_DEVCONTAINER_DIR == 'false'
       shell: bash
       run: exit 0
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'true'
+      if: env.HAS_DEVCONTAINER_DIR == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in .devcontainer directory"
-      if: steps.checkdevcontainer.outputs.HAS_DEVCONTAINER_DIR == 'false'
+      if: env.HAS_DEVCONTAINER_DIR == 'false'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: .devcontainer

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -121,7 +121,7 @@ runs:
 
     - name: "Run Dockerfile linting in docker directory"
       if: env.HAS_DOCKER_DIR == 'true' && env.RUN_DOCKER_LINT == 'true'
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      uses: ansys/actions/docker-style@main
       with:
         directory: docker
         recursive: ${{ inputs.docker-recursive }}
@@ -157,7 +157,7 @@ runs:
 
     - name: "Run Dockerfile linting in .devcontainer directory"
       if: env.HAS_DEVCONTAINER_DIR == 'false' && env.RUN_DOCKER_LINT == 'true'
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      uses: ansys/actions/docker-style@main
       with:
         directory: .devcontainer
         error-level: ${{ inputs.docker-error-level }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -6,7 +6,14 @@ description: >
   <https://github.com/pre-commit/pre-commit/>`_. The action installs and runs
   ``pre-commit``. It is assumed that your project contains a
   ``.pre-commit-config.yaml`` file in the root directory. The action can also
-  be extended to lint docker files.
+  be extended to lint docker files that are contained in docker and
+  .devcontainer.
+
+    .. warning::
+
+      If docker lint is enabled and directories docker or .devcontainer exist,
+      the action will fail if it doesn't find a Dockerfile.
+
 
 inputs:
 
@@ -49,13 +56,6 @@ inputs:
     default: 2
     type: int
 
-  docker-directory:
-    description: >
-      Directory from which to search for Dockerfile(s).
-    required: false
-    default: docker
-    type: string
-
 runs:
   using: "composite"
   steps:
@@ -88,13 +88,22 @@ runs:
         level: "INFO"
         message: >
           Extend the workflow to lint Dockerfile(s) in
-          '${{ github.workspace }}/docker'.
+          '${{ github.workspace }}/docker' and
+          '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in docker directory"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
-        directory: ${{ inputs.docker-directory }}
+        directory: docker
+        recursive: ${{ inputs.docker-recursive }}
+        error-level: ${{ inputs.docker-error-level }}
+
+    - name: "Run Dockerfile linting in docker directory"
+      if: ${{ inputs.docker-lint == 'true' }}
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      with:
+        directory: .devcontainer
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -91,19 +91,11 @@ runs:
         message: >
           Extend the workflow to lint Dockerfile(s).
 
-    - name: "Run Dockerfile linting in 'docker' directory"
+    - name: "Run Dockerfile linting in directories 'docker' and '.devcontainer'"
       if: ${{ inputs.docker-lint == 'true' }}
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
-        directory: docker
-        recursive: ${{ inputs.docker-recursive }}
-        error-level: ${{ inputs.docker-error-level }}
-
-    - name: "Run Dockerfile linting in '.devcontainer' directory"
-      if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
-      with:
-        directory: .devcontainer
+        directory: "docker .devcontainer"
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -99,16 +99,13 @@ runs:
         recursive: ${{ inputs.docker-recursive }}
         error-level: ${{ inputs.docker-error-level }}
 
-    # FIXME: Currently the action cannot work with multiple directory
-    # because of a bug, see
-    # https://github.com/jbergstroem/hadolint-gh-action/pull/135
-    # - name: "Run Dockerfile linting in '.devcontainer' directory"
-    #   if: ${{ inputs.docker-lint == 'true' }}
-    #   uses: ansys/actions/docker-style@feat/lint_dockerfile
-    #   with:
-    #     directory: .devcontainer
-    #     recursive: ${{ inputs.docker-recursive }}
-    #     error-level: ${{ inputs.docker-error-level }}
+    - name: "Run Dockerfile linting in '.devcontainer' directory"
+      if: ${{ inputs.docker-lint == 'true' }}
+      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      with:
+        directory: .devcontainer
+        recursive: ${{ inputs.docker-recursive }}
+        error-level: ${{ inputs.docker-error-level }}
 
     # ------------------------------------------------------------------------
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -85,7 +85,7 @@ runs:
     - name: "Exit if docker-lint is false"
       shell: bash
       run: |
-        if ${{ inputs.docker-lint }} == false ; then
+        if ${{ inputs.docker-lint }} == 'false' ; then
           exit 0
         fi
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -87,6 +87,8 @@ runs:
       run: |
         if [[ "${{ inputs.docker-lint }}" == "false" ]]; then
           exit 0
+        else
+          echo "SOMETHIN STRANGE IS HAPPENING"
         fi
 
     # ------------------------------------------------------------------------

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -156,7 +156,7 @@ runs:
           Lint directory '${{ github.workspace }}/.devcontainer'.
 
     - name: "Run Dockerfile linting in .devcontainer directory"
-      if: env.HAS_DEVCONTAINER_DIR == 'false' & env.RUN_DOCKER_LINT == 'true'
+      if: env.HAS_DEVCONTAINER_DIR == 'false' && env.RUN_DOCKER_LINT == 'true'
       uses: ansys/actions/docker-style@feat/lint_dockerfile
       with:
         directory: .devcontainer

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: "Run Dockerfile linting in docker directory"
       uses: ansys/actions/docker-style@main
-      if: steps.checkdocker.outputs.exists == 'true'
+      if: env.HAS_DOCKER_DIR == 'true'
       with:
         directory: docker
         recursive: ${{ inputs.docker-recursive }}

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -85,7 +85,7 @@ runs:
     - name: "Exit if docker-lint is false"
       shell: bash
       run: |
-        if ${{ inputs.docker-lint }} == 'false' ; then
+        if [ ${{ inputs.docker-lint }} == false ]; then
           exit 0
         fi
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: "Run Dockerfile linting in directories 'docker' and '.devcontainer'"
       if: ${{ inputs.docker-lint == 'true' }}
-      uses: ansys/actions/docker-style@feat/lint_dockerfile
+      uses: ansys/actions/docker-style@main
       with:
         directory: "docker .devcontainer"
         recursive: ${{ inputs.docker-recursive }}

--- a/doc/source/style-actions/examples/docker-style-basic.yml
+++ b/doc/source/style-actions/examples/docker-style-basic.yml
@@ -2,8 +2,7 @@ docker-style:
   name: "Docker style"
   runs-on: ubuntu-latest
   steps:
-    - name: "Run PyAnsys docker style checks"
-      uses: ansys/actions/docker-style@{{ version }}
+    - uses: ansys/actions/docker-style@{{ version }}
       with:
         directory: docker
         recursive: true

--- a/doc/source/style-actions/examples/docker-style-basic.yml
+++ b/doc/source/style-actions/examples/docker-style-basic.yml
@@ -1,5 +1,5 @@
-code-style:
-  name: "Running docker style checks"
+docker-style:
+  name: "Docker style"
   runs-on: ubuntu-latest
   steps:
     - name: "Run PyAnsys docker style checks"

--- a/doc/source/style-actions/index.rst
+++ b/doc/source/style-actions/index.rst
@@ -6,6 +6,7 @@ with PyAnsys guidelines.
 
 Code style action
 -----------------
+
 .. jinja:: code-style
 
     {{ description }}
@@ -27,6 +28,7 @@ Code style action
 
 Doc style action
 ----------------
+
 .. jinja:: doc-style
 
     {{ description }}

--- a/doc/source/style-actions/index.rst
+++ b/doc/source/style-actions/index.rst
@@ -48,6 +48,7 @@ Doc style action
 
 Docker style action
 -------------------
+
 .. jinja:: docker-style
 
     {{ description }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -114,7 +114,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: ${{ env.EXISTING_DIRS }} != ""
+      if: ${{ !!env.EXISTING_DIRS }}
       with:
         level: "INFO"
         message: >
@@ -147,8 +147,8 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ env.NON_EXISTING_DIRS }} != '' &&
-        contains(env.NON_EXISTING_DIRS, " ")
+        ${{ !!env.NON_EXISTING_DIRS &&
+        contains(env.NON_EXISTING_DIRS, " ") }}
       with:
         level: "WARNING"
         message: >
@@ -156,8 +156,8 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ env.NON_EXISTING_DIRS }} != '' &&
-        !contains(env.NON_EXISTING_DIRS, " ")
+        ${{ !!env.NON_EXISTING_DIRS &&
+        !contains(env.NON_EXISTING_DIRS, " ") }}
       with:
         level: "WARNING"
         message: >

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -146,16 +146,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: |
-        ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
+      if: ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
       with:
         level: "WARNING"
         message: >
           Non existing directories: '${{ env.NON_EXISTING_DIRS }}'
 
     - uses: ansys/actions/_logging@main
-      if: |
-        ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
+      if: ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
       with:
         level: "WARNING"
         message: >

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -43,7 +43,7 @@ inputs:
 
   error-level:
     description: >
-      Fail action based on hadolint output (-1: never, 0: error,1: warning,
+      Fail action based on hadolint output (-1: never, 0: error, 1: warning,
       2: info)
     required: false
     default: 2

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1.12.1
+      uses: jbergstroem/hadolint-gh-action@v1.12.2
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1.12.2
+      uses: jbergstroem/hadolint-gh-action@v1
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1.11
+      uses: jbergstroem/hadolint-gh-action@v1.11.0
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -152,7 +152,7 @@ runs:
       with:
         level: "WARNING"
         message: >
-          Non existing directories: '${{ env.NON_EXISTING_DIRS }}''
+          Non existing directories: '${{ env.NON_EXISTING_DIRS }}'
 
     - uses: ansys/actions/_logging@main
       if: |
@@ -161,4 +161,4 @@ runs:
       with:
         level: "WARNING"
         message: >
-          Non existing directory: '${{ env.NON_EXISTING_DIRS }}''
+          Non existing directory: '${{ env.NON_EXISTING_DIRS }}'

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -3,9 +3,9 @@ name: >
 
 description: >
   Evaluate the quality of your project Dockerfile(s) by using `hadolint
-  <https://github.com/hadolint/hadolint/>`_. This action is expected to
-  be used within a matrix job to lint Dockerfile(s) from multiple directories.
-  The action uses `hadolint-gh-action
+  <https://github.com/hadolint/hadolint/>`_. This action can be used to
+  lint Dockerfile(s) from multiple directories, see input "directory"
+  description. The action uses `hadolint-gh-action
   <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes.
   If you want to evaluate multiple Dockerfiles contained in various
   directories of the provided directory, use the recursive option.
@@ -29,7 +29,9 @@ inputs:
 
   directory:
     description: >
-      Directory from which to search for Dockerfile(s).
+      Directory from which to search for Dockerfile(s). You can pass multiple
+      directories for processing by separating them with spaces, e.g.
+      "docker .devcontainer".
     required: false
     default: docker
     type: string
@@ -88,46 +90,75 @@ runs:
       with:
         level: "INFO"
         message: >
-          Check that directory
-          '${{ github.workspace }}/${{ inputs.directory }}' exists. If not,
-          a warning is raised and nothing is done.
+          Check that directory (or diresctories) exist(s). If not, a warning
+          is raised and non existing ones are ignored.
 
-    - name: "Check if directory input exists"
+    - name: "Filter input directory"
       shell: bash
       run: |
-        if [ -d "${{ github.workspace }}/${{ inputs.directory }}" ]; then
-          echo "DIRECTORY_EXISTS=true" >> $GITHUB_ENV
-        else
-          echo "DIRECTORY_EXISTS=false" >> $GITHUB_ENV
-        fi
+        EXISTING_DIRS=""
+        NON_EXISTING_DIRS=""
+        for directory in ${{ inputs.directory }}
+        do
+          if [ -d "${{ github.workspace }}/$directory" ]; then
+            EXISTING_DIRS+="$directory "
+          else
+            NON_EXISTING_DIRS+="$directory "
+          fi
+        done
+        EXISTING_DIRS=${EXISTING_DIRS%% }
+        echo "EXISTING_DIRS=$EXISTING_DIRS" >> $GITHUB_ENV
+        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%% }
+        echo "NON_EXISTING_DIRS=$NON_EXISTING_DIRS" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_EXISTS == 'true'
+      if: env.EXISTING_DIRS != ""
       with:
         level: "INFO"
         message: >
-          Lint directory '${{ github.workspace }}/${{ inputs.directory }}'.
+          Lint '${{ inputs.directory }}'.
+
+    - name: "Format Hadolint dockerfile input"
+      if: env.EXISTING_DIRS != ""
+      shell: bash
+      run: |
+        fmt_directory="${{ inputs.directory }}"
+        if [[ "${{ inputs.recursive }}" == 'true' ]]; then
+          fmt_directory_array=($fmt_directory)
+          for i in "${!fmt_directory_array[@]}"; do
+            fmt_directory_array[i]="${fmt_directory_array[i]}**/Dockerfile"
+          done
+          fmt_directory="${fmt_directory_array[*]}"
+        else
+          fmt_directory="${directories}/Dockerfile"
+        fi
+        echo "FORMATED_HADOLINT_DOCKERFILE_INPUT=$fmt_directory" >> $GITHUB_ENV
 
     - name: "Run Hadolint"
-      if: env.DIRECTORY_EXISTS == 'true'
+      if: env.EXISTING_DIRS != ""
       uses: jbergstroem/hadolint-gh-action@v1
       with:
-        dockerfile: >-
-          ${{
-            inputs.recursive == 'true' &&
-            format('{0}/**/Dockerfile', inputs.directory) ||
-            format('{0}/Dockerfile', inputs.directory)
-          }}
+        dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_EXISTS == 'false'
+      if: |
+        env.NON_EXISTING_DIRS != "" &&
+        contains(env.NON_EXISTING_DIRS, " ")
       with:
         level: "WARNING"
         message: >
-          Directory '${{ github.workspace }}/${{ inputs.directory }}' does not
-          exists.
+          Non existing directories: ${{ env.NON_EXISTING_DIRS }}
+
+    - uses: ansys/actions/_logging@main
+      if: |
+        env.NON_EXISTING_DIRS != "" &&
+        !contains(env.NON_EXISTING_DIRS, " ")
+      with:
+        level: "WARNING"
+        message: >
+          Non existing directory: ${{ env.NON_EXISTING_DIRS }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -58,19 +58,18 @@ runs:
           If it does not, then the rest of the action should not be performed.
 
     - name: "Check if docker directory exists"
-      id: checkdocker
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "HAS_DOCKER_DIR='true'" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR=true" >> $GITHUB_ENV
         else
-          echo "HAS_DOCKER_DIR='false'" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR=false" >> $GITHUB_ENV
         fi
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
+      if: env.HAS_DOCKER_DIR == 'false'
       with:
         level: "WARNING"
         message: >
@@ -80,7 +79,7 @@ runs:
           directory at the root of the repository.
 
     - name: "Exit workflow"
-      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
+      if: env.HAS_DOCKER_DIR == 'false'
       shell: bash
       run: exit 1
 
@@ -95,44 +94,43 @@ runs:
 
     # Changes performed in allowed_working_dirs should be applied to the code-style action.
     - name: "Check provided directory"
-      id: checkdir
       shell: bash
       run: |
         allowed_working_dirs=("docker" ".devcontainer")
-        is_allowed='false'
+        is_allowed=false
         for dir in "${allowed_working_dirs[@]}"
         do
           if [ "$dir" == "${{ inputs.directory }}" ] ; then
-            is_allowed='true'
+            is_allowed=true
           fi
         done
-        echo "DIRECTORY_ALLOWED=$is_allowed" >> $GITHUB_OUTPUT
+        echo "DIRECTORY_ALLOWED=$is_allowed" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'false'
+      if: env.DIRECTORY_ALLOWED == 'false'
       with:
         level: "ERROR"
         message: >
           Exit action because the provided directory isn't allowed.
 
     - name: "Exit workflow"
-      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'false'
+      if: env.DIRECTORY_ALLOWED == 'false'
       shell: bash
       run: exit 1
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'true'
+      if: env.DIRECTORY_ALLOWED == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/${{ inputs.directory }}'.
 
     - name: "Run Hadolint"
-      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'true'
+      if: env.DIRECTORY_ALLOWED == 'true'
       uses: jbergstroem/hadolint-gh-action@v1
       with:
         dockerfile: ${{ inputs.recursive == 'true' && format('{0}/**/Dockerfile', inputs.directory) || format('{0}/Dockerfile', inputs.directory) }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -128,7 +128,7 @@ runs:
         if [[ "${{ inputs.recursive }}" == 'true' ]]; then
           fmt_directory_array=($fmt_directory)
           for i in "${!fmt_directory_array[@]}"; do
-            fmt_directory_array[i]="${fmt_directory_array[i]}**/Dockerfile"
+            fmt_directory_array[i]="${fmt_directory_array[i]}/**/Dockerfile"
           done
           fmt_directory="${fmt_directory_array[*]}"
         else
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1
+      uses: jbergstroem/hadolint-gh-action@v1.11
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -114,14 +114,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.EXISTING_DIRS != ""
+      if: ${{ env.EXISTING_DIRS }} != ""
       with:
         level: "INFO"
         message: >
           Lint '${{ inputs.directory }}'.
 
     - name: "Format Hadolint dockerfile input"
-      if: env.EXISTING_DIRS != ""
+      if: ${{ !!env.EXISTING_DIRS }}
       shell: bash
       run: |
         fmt_directory="${{ inputs.directory }}"
@@ -137,7 +137,7 @@ runs:
         echo "FORMATED_HADOLINT_DOCKERFILE_INPUT=$fmt_directory" >> $GITHUB_ENV
 
     - name: "Run Hadolint"
-      if: env.EXISTING_DIRS != ""
+      if: ${{ !!env.EXISTING_DIRS }}
       uses: jbergstroem/hadolint-gh-action@v1
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
@@ -147,7 +147,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        env.NON_EXISTING_DIRS != "" &&
+        ${{ !!env.NON_EXISTING_DIRS }} &&
         contains(env.NON_EXISTING_DIRS, " ")
       with:
         level: "WARNING"
@@ -156,7 +156,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        env.NON_EXISTING_DIRS != "" &&
+        ${{ !!env.NON_EXISTING_DIRS }} &&
         !contains(env.NON_EXISTING_DIRS, " ")
       with:
         level: "WARNING"

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -106,9 +106,9 @@ runs:
             NON_EXISTING_DIRS+="$directory "
           fi
         done
-        EXISTING_DIRS=${EXISTING_DIRS%%}
+        EXISTING_DIRS=$(echo -n "$EXISTING_DIRS" | xargs)
         echo "EXISTING_DIRS=$EXISTING_DIRS" >> $GITHUB_ENV
-        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%%}
+        NON_EXISTING_DIRS=$(echo -n "$NON_EXISTING_DIRS" | xargs)
         echo "NON_EXISTING_DIRS=$NON_EXISTING_DIRS" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -152,7 +152,7 @@ runs:
       with:
         level: "WARNING"
         message: >
-          Non existing directories: ${{ env.NON_EXISTING_DIRS }}
+          Non existing directories: '${{ env.NON_EXISTING_DIRS }}''
 
     - uses: ansys/actions/_logging@main
       if: |
@@ -161,4 +161,4 @@ runs:
       with:
         level: "WARNING"
         message: >
-          Non existing directory: ${{ env.NON_EXISTING_DIRS }}
+          Non existing directory: '${{ env.NON_EXISTING_DIRS }}''

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -9,6 +9,9 @@ description: >
   <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes.
   If you want to evaluate multiple Dockerfiles contained in various
   directories of the provided directory, use the recursive option.
+  When linting a Dockerfile dedicated to Windows, one should use hadolint
+  shell pragma to avoid false positives from ShellCheck, see `hadolint shell pragma
+  <https://github.com/hadolint/hadolint/pull/708>`_.
 
   .. note::
 

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -8,8 +8,8 @@ description: >
   <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes. If you want to evaluate multiple
   Dockerfiles contained in various directories of the provided directory, use the recursive option.
 
-  This action emphasis the fact of having Dockerfile(s) contained inside the 'docker' directory in the
-  root of the project. Exception can be added as it is the case for the ''.devcontainer' directory.
+  This action emphasizes the fact of having Dockerfile(s) contained inside the 'docker' directory in the
+  root of the project. Exceptions can be added as it is the case for the ''.devcontainer' directory.
 
   .. warning::
 

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -106,9 +106,9 @@ runs:
             NON_EXISTING_DIRS+="$directory "
           fi
         done
-        EXISTING_DIRS=${EXISTING_DIRS%%}
+        EXISTING_DIRS=${EXISTING_DIRS%% }
         echo "EXISTING_DIRS=$EXISTING_DIRS" >> $GITHUB_ENV
-        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%%}
+        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%% }
         echo "NON_EXISTING_DIRS=$NON_EXISTING_DIRS" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -87,7 +87,7 @@ runs:
       with:
         level: "INFO"
         message: >
-          Check that the provided directory is among allowed directories, i.e.
+          Check that '${{ inputs.directory }}' is among allowed directories, i.e.
           'docker' and '.devcontainer'.
 
     # Changes performed in allowed_working_dirs should be applied to the code-style action.

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -8,13 +8,15 @@ description: >
   <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes. If you want to evaluate multiple
   Dockerfiles contained in various directories of the provided directory, use the recursive option.
 
-  This action emphasis the fact of having Dockerfile(s) contained inside the "docker" directory in the
-  root of the project. Exception can be added as it is the case for the ".devcontainer" directory.
+  This action emphasis the fact of having Dockerfile(s) contained inside the 'docker' directory in the
+  root of the project. Exception can be added as it is the case for the ''.devcontainer' directory.
 
   .. warning::
+      This action only looks for docker files named Dockerfile.
+      A docker file like Dockerfile.linux will not be linted.
       Two checks are performed and failing any of them results in the action failure:
-      - the root of the project must contain a docker directory;
-      - the provided directory must be allowed, i.e. is either "docker" or ".devcontainer".
+      - the root of the project must contain a 'docker' directory;
+      - the provided directory must be allowed, i.e. is either 'docker' or '.devcontainer'.
 
 inputs:
 
@@ -46,13 +48,47 @@ runs:
   using: "composite"
   steps:
 
-    - name: "Check docker directory existence"
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Check that directory 'docker' exists at the root of the repository.
+          If it does not, then the rest of the action should not be performed.
+
+    - name: "Check if docker directory exists"
       shell: bash
       run: |
-        if [ ! -d "${{ github.workspace }}/docker" ]; then
-          echo "Directory 'docker' does not exist. Except in special cases, e.g. '.devcontainer', we emphasize that dockerfiles are expected to be in the docker directory in the root of the project."
-          exit 1
+        if [ -d "${{ github.workspace }}/docker" ]; then
+          echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
         fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.HAS_DOCKER_DIR == 'false'
+      with:
+        level: "WARNING"
+        message: >
+          Exit action as no 'docker' directory exists at the root of the
+          repository. Except in special cases, e.g. '.devcontainer', we
+          emphasize that docker files are expected to be in the 'docker'
+          directory at the root of the repository.
+
+    - name: "Exit workflow"
+      if: env.HAS_DOCKER_DIR == 'false'
+      shell: bash
+      run: exit 1
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Check that the provided directory is among allowed directories, i.e.
+          'docker' and '.devcontainer'.
 
     # Changes performed in allowed_working_dirs should be applied to the code-style action.
     - name: "Check provided directory"
@@ -66,12 +102,30 @@ runs:
             is_allowed=true
           fi
         done
-        if [ "$is_allowed" == true ] ; then
-          echo "Provided directory '${{ inputs.directory }}' is allowed"
-        else
-          echo "Provided directory '${{ inputs.directory }}' is not allowed"
-          exit 1
-        fi
+        echo "DIRECTORY_ALLOWED=$is_allowed" >> $GITHUB_OUTPUT
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.DIRECTORY_ALLOWED == 'false'
+      with:
+        level: "ERROR"
+        message: >
+          Exit action because the provided directory isn't allowed.
+
+    - name: "Exit workflow"
+      if: env.DIRECTORY_ALLOWED == 'false'
+      shell: bash
+      run: exit 1
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.DIRECTORY_ALLOWED == 'false'
+      with:
+        level: "INFO"
+        message: >
+          Lint directory '${{ github.workspace }}/${{ inputs.directory }}'.
 
     - name: "Run Hadolint"
       uses: jbergstroem/hadolint-gh-action@v1

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -147,8 +147,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ !!env.NON_EXISTING_DIRS &&
-        contains(env.NON_EXISTING_DIRS, " ") }}
+        ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
       with:
         level: "WARNING"
         message: >
@@ -156,8 +155,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ !!env.NON_EXISTING_DIRS &&
-        !contains(env.NON_EXISTING_DIRS, " ") }}
+        ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
       with:
         level: "WARNING"
         message: >

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -61,9 +61,9 @@ runs:
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
-          echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR='true'" >> $GITHUB_OUTPUT
         else
-          echo "HAS_DOCKER_DIR=false" >> $GITHUB_OUTPUT
+          echo "HAS_DOCKER_DIR='false'" >> $GITHUB_OUTPUT
         fi
 
     # ------------------------------------------------------------------------
@@ -97,11 +97,11 @@ runs:
       shell: bash
       run: |
         allowed_working_dirs=("docker" ".devcontainer")
-        is_allowed=false
+        is_allowed='false'
         for dir in "${allowed_working_dirs[@]}"
         do
           if [ "$dir" == "${{ inputs.directory }}" ] ; then
-            is_allowed=true
+            is_allowed='true'
           fi
         done
         echo "DIRECTORY_ALLOWED=$is_allowed" >> $GITHUB_OUTPUT

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -12,6 +12,7 @@ description: >
   root of the project. Exception can be added as it is the case for the ''.devcontainer' directory.
 
   .. warning::
+
       This action only looks for docker files named Dockerfile.
       A docker file like Dockerfile.linux will not be linted.
       Two checks are performed and failing any of them results in the action failure:

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -78,9 +78,9 @@ runs:
       with:
         level: "WARNING"
         message: >
-          No 'docker' directory found. Except in special cases, e.g.
-          '.devcontainer', we emphasize that docker files are stored in the
-          'docker' directory at the root of the repository.
+          No 'docker' directory found. If possible, please follow the common
+          approach of storing docker files in the 'docker' directory at the
+          root of the repository.
 
     # ------------------------------------------------------------------------
 

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -108,7 +108,7 @@ runs:
           Lint directory '${{ github.workspace }}/${{ inputs.directory }}'.
 
     - name: "Run Hadolint"
-      if: env.DIRECTORY_ALLOWED == 'true'
+      if: env.DIRECTORY_EXISTS == 'true'
       uses: jbergstroem/hadolint-gh-action@v1
       with:
         dockerfile: >-

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -106,9 +106,9 @@ runs:
             NON_EXISTING_DIRS+="$directory "
           fi
         done
-        EXISTING_DIRS=${EXISTING_DIRS%% }
+        EXISTING_DIRS=${EXISTING_DIRS%%}
         echo "EXISTING_DIRS=$EXISTING_DIRS" >> $GITHUB_ENV
-        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%% }
+        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%%}
         echo "NON_EXISTING_DIRS=$NON_EXISTING_DIRS" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -124,7 +124,7 @@ runs:
       if: ${{ !!env.EXISTING_DIRS }}
       shell: bash
       run: |
-        fmt_directory="${{ inputs.directory }}"
+        fmt_directory="${{ env.EXISTING_DIRS }}"
         pattern="${{ inputs.recursive == 'true' && '/**' || '' }}/Dockerfile"
         fmt_directory_array=($fmt_directory)
         for i in "${!fmt_directory_array[@]}"; do

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -118,7 +118,7 @@ runs:
       with:
         level: "INFO"
         message: >
-          Lint '${{ inputs.directory }}'.
+          Lint '${{ env.EXISTING_DIRS }}'.
 
     - name: "Format Hadolint dockerfile input"
       if: ${{ !!env.EXISTING_DIRS }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -58,6 +58,7 @@ runs:
           If it does not, then the rest of the action should not be performed.
 
     - name: "Check if docker directory exists"
+      id: checkdocker
       shell: bash
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
@@ -69,7 +70,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.HAS_DOCKER_DIR == 'false'
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
       with:
         level: "WARNING"
         message: >
@@ -79,7 +80,7 @@ runs:
           directory at the root of the repository.
 
     - name: "Exit workflow"
-      if: env.HAS_DOCKER_DIR == 'false'
+      if: steps.checkdocker.outputs.HAS_DOCKER_DIR == 'false'
       shell: bash
       run: exit 1
 
@@ -94,6 +95,7 @@ runs:
 
     # Changes performed in allowed_working_dirs should be applied to the code-style action.
     - name: "Check provided directory"
+      id: checkdir
       shell: bash
       run: |
         allowed_working_dirs=("docker" ".devcontainer")
@@ -109,27 +111,28 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_ALLOWED == 'false'
+      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'false'
       with:
         level: "ERROR"
         message: >
           Exit action because the provided directory isn't allowed.
 
     - name: "Exit workflow"
-      if: env.DIRECTORY_ALLOWED == 'false'
+      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'false'
       shell: bash
       run: exit 1
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_ALLOWED == 'false'
+      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'true'
       with:
         level: "INFO"
         message: >
           Lint directory '${{ github.workspace }}/${{ inputs.directory }}'.
 
     - name: "Run Hadolint"
+      if: steps.checkdir.outputs.DIRECTORY_ALLOWED == 'true'
       uses: jbergstroem/hadolint-gh-action@v1
       with:
         dockerfile: ${{ inputs.recursive == 'true' && format('{0}/**/Dockerfile', inputs.directory) || format('{0}/Dockerfile', inputs.directory) }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -125,15 +125,12 @@ runs:
       shell: bash
       run: |
         fmt_directory="${{ inputs.directory }}"
-        if [[ "${{ inputs.recursive }}" == 'true' ]]; then
-          fmt_directory_array=($fmt_directory)
-          for i in "${!fmt_directory_array[@]}"; do
-            fmt_directory_array[i]="${fmt_directory_array[i]}/**/Dockerfile"
-          done
-          fmt_directory="${fmt_directory_array[*]}"
-        else
-          fmt_directory="${directories}/Dockerfile"
-        fi
+        pattern="${{ inputs.recursive == 'true' && '/**' || '' }}/Dockerfile"
+        fmt_directory_array=($fmt_directory)
+        for i in "${!fmt_directory_array[@]}"; do
+          fmt_directory_array[i]="${fmt_directory_array[i]}${pattern}"
+        done
+        fmt_directory="${fmt_directory_array[*]}"
         echo "FORMATED_HADOLINT_DOCKERFILE_INPUT=$fmt_directory" >> $GITHUB_ENV
 
     - name: "Run Hadolint"

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -3,33 +3,33 @@ name: >
 
 description: >
   Evaluate the quality of your project Dockerfile(s) by using `hadolint
-  <https://github.com/hadolint/hadolint/>`_. This action is expected to be used within a
-  matrix job to lint Dockerfile(s) from multiple directories. The action uses `hadolint-gh-action
-  <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes. If you want to evaluate multiple
-  Dockerfiles contained in various directories of the provided directory, use the recursive option.
+  <https://github.com/hadolint/hadolint/>`_. This action is expected to
+  be used within a matrix job to lint Dockerfile(s) from multiple directories.
+  The action uses `hadolint-gh-action
+  <https://github.com/jbergstroem/hadolint-gh-action>`_ behind the scenes.
+  If you want to evaluate multiple Dockerfiles contained in various
+  directories of the provided directory, use the recursive option.
 
-  This action emphasizes the fact of having Dockerfile(s) contained inside the 'docker' directory in the
-  root of the project. Exceptions can be added as it is the case for the ''.devcontainer' directory.
+  .. note::
+
+      This action emphasizes the fact of having Dockerfile(s) contained inside the
+      'docker' directory in the root of the project.
 
   .. warning::
 
       This action only looks for docker files named Dockerfile.
       A docker file like Dockerfile.linux will not be linted.
-      Two checks are performed and failing any of them results in the action failure:
-      - the root of the project must contain a 'docker' directory;
-      - the provided directory must be allowed, i.e. is either 'docker' or '.devcontainer'.
 
 inputs:
 
-  # Required inputs
+  # Optional inputs
 
   directory:
     description: >
       Directory from which to search for Dockerfile(s).
-    required: true
+    required: false
+    default: docker
     type: string
-
-  # Optional inputs
 
   recursive:
     description: >
@@ -40,7 +40,8 @@ inputs:
 
   error-level:
     description: >
-      Fail action based on hadolint output (-1: never, 0: error, 1: warning, 2: info)
+      Fail action based on hadolint output (-1: never, 0: error,1: warning,
+      2: info)
     required: false
     default: 2
     type: int
@@ -56,7 +57,7 @@ runs:
         level: "INFO"
         message: >
           Check that directory 'docker' exists at the root of the repository.
-          If it does not, then the rest of the action should not be performed.
+          If it does not, then a warning is emitted.
 
     - name: "Check if docker directory exists"
       shell: bash
@@ -74,15 +75,9 @@ runs:
       with:
         level: "WARNING"
         message: >
-          Exit action as no 'docker' directory exists at the root of the
-          repository. Except in special cases, e.g. '.devcontainer', we
-          emphasize that docker files are expected to be in the 'docker'
-          directory at the root of the repository.
-
-    - name: "Exit workflow"
-      if: env.HAS_DOCKER_DIR == 'false'
-      shell: bash
-      run: exit 1
+          No 'docker' directory found. Except in special cases, e.g.
+          '.devcontainer', we emphasize that docker files are stored in the
+          'docker' directory at the root of the repository.
 
     # ------------------------------------------------------------------------
 
@@ -90,41 +85,23 @@ runs:
       with:
         level: "INFO"
         message: >
-          Check that '${{ inputs.directory }}' is among allowed directories, i.e.
-          'docker' and '.devcontainer'.
+          Check that directory
+          '${{ github.workspace }}/${{ inputs.directory }}' exists. If not,
+          a warning is raised and nothing is done.
 
-    # Changes performed in allowed_working_dirs should be applied to the code-style action.
-    - name: "Check provided directory"
+    - name: "Check if directory input exists"
       shell: bash
       run: |
-        allowed_working_dirs=("docker" ".devcontainer")
-        is_allowed=false
-        for dir in "${allowed_working_dirs[@]}"
-        do
-          if [ "$dir" == "${{ inputs.directory }}" ] ; then
-            is_allowed=true
-          fi
-        done
-        echo "DIRECTORY_ALLOWED=$is_allowed" >> $GITHUB_ENV
+        if [ -d "${{ github.workspace }}/${{ inputs.directory }}" ]; then
+          echo "DIRECTORY_EXISTS=true" >> $GITHUB_ENV
+        else
+          echo "DIRECTORY_EXISTS=false" >> $GITHUB_ENV
+        fi
 
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_ALLOWED == 'false'
-      with:
-        level: "ERROR"
-        message: >
-          Exit action because the provided directory isn't allowed.
-
-    - name: "Exit workflow"
-      if: env.DIRECTORY_ALLOWED == 'false'
-      shell: bash
-      run: exit 1
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      if: env.DIRECTORY_ALLOWED == 'true'
+      if: env.DIRECTORY_EXISTS == 'true'
       with:
         level: "INFO"
         message: >
@@ -134,5 +111,20 @@ runs:
       if: env.DIRECTORY_ALLOWED == 'true'
       uses: jbergstroem/hadolint-gh-action@v1
       with:
-        dockerfile: ${{ inputs.recursive == 'true' && format('{0}/**/Dockerfile', inputs.directory) || format('{0}/Dockerfile', inputs.directory) }}
+        dockerfile: >-
+          ${{
+            inputs.recursive == 'true' &&
+            format('{0}/**/Dockerfile', inputs.directory) ||
+            format('{0}/Dockerfile', inputs.directory)
+          }}
         error_level: ${{ inputs.error-level }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: env.DIRECTORY_EXISTS == 'false'
+      with:
+        level: "WARNING"
+        message: >
+          Directory '${{ github.workspace }}/${{ inputs.directory }}' does not
+          exists.

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -62,6 +62,8 @@ runs:
       run: |
         if [ -d "${{ github.workspace }}/docker" ]; then
           echo "HAS_DOCKER_DIR=true" >> $GITHUB_OUTPUT
+        else
+          echo "HAS_DOCKER_DIR=false" >> $GITHUB_OUTPUT
         fi
 
     # ------------------------------------------------------------------------

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -90,8 +90,8 @@ runs:
       with:
         level: "INFO"
         message: >
-          Check that directory (or diresctories) exist(s). If not, a warning
-          is raised and non existing ones are ignored.
+          Check that directory input exist. If not, a warning is raised and
+          non existing ones (if any) are ignored.
 
     - name: "Filter input directory"
       shell: bash

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1.11.0
+      uses: jbergstroem/hadolint-gh-action@v1.12.0
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -147,7 +147,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ !!env.NON_EXISTING_DIRS }} &&
+        ${{ env.NON_EXISTING_DIRS }} != '' &&
         contains(env.NON_EXISTING_DIRS, " ")
       with:
         level: "WARNING"
@@ -156,7 +156,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       if: |
-        ${{ !!env.NON_EXISTING_DIRS }} &&
+        ${{ env.NON_EXISTING_DIRS }} != '' &&
         !contains(env.NON_EXISTING_DIRS, " ")
       with:
         level: "WARNING"

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -138,7 +138,7 @@ runs:
 
     - name: "Run Hadolint"
       if: ${{ !!env.EXISTING_DIRS }}
-      uses: jbergstroem/hadolint-gh-action@v1.12.0
+      uses: jbergstroem/hadolint-gh-action@v1.12.1
       with:
         dockerfile: ${{ env.FORMATED_HADOLINT_DOCKERFILE_INPUT }}
         error_level: ${{ inputs.error-level }}

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -106,9 +106,9 @@ runs:
             NON_EXISTING_DIRS+="$directory "
           fi
         done
-        EXISTING_DIRS=${EXISTING_DIRS%% }
+        EXISTING_DIRS=${EXISTING_DIRS%%}
         echo "EXISTING_DIRS=$EXISTING_DIRS" >> $GITHUB_ENV
-        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%% }
+        NON_EXISTING_DIRS=${NON_EXISTING_DIRS%%}
         echo "NON_EXISTING_DIRS=$NON_EXISTING_DIRS" >> $GITHUB_ENV
 
     # ------------------------------------------------------------------------
@@ -153,7 +153,7 @@ runs:
           Non existing directories: '${{ env.NON_EXISTING_DIRS }}'
 
     - uses: ansys/actions/_logging@main
-      if: ${{ env.NON_EXISTING_DIRS != '' && contains(env.NON_EXISTING_DIRS, ' ') }}
+      if: ${{ env.NON_EXISTING_DIRS != '' && !contains(env.NON_EXISTING_DIRS, ' ') }}
       with:
         level: "WARNING"
         message: >


### PR DESCRIPTION
This PR addresses #381 by :
1. adding an extra action ("docker-style") that can be used to evaluate the Dockerfile(s) associated to a repo;
2. extending action "code-style" by triggering "docker-style" on "docker/Dockerfile" and ".devcontainer/Dockerfile" if the associated directories exist.

It was tested and validated in a sandbox. If you are interested, you can see the CI jobs failing and succeeding when expected (https://github.com/SMoraisAnsys/pyansys-geometry/actions/runs/7628030247/job/21173613810?pr=1).

Here is a summary of the changes:

TLDR
------
- docker-style looks for files named "Dockerfile" in the provided directory (default to "docker"). If one wants to propose and evaluate multiple docker files, then the associated repo must follow a directory oriented architecture (e.g. docker/linux/Dockerfile and docker/windows/Dockerfile) and option `recursive` must be set to `true`.
- docker-style fails based on `hadolint` output and one can define at which ouput level the action fails through option `error-level`.
- code-style can be extend to perform docker linting on "docker" and ".devcontainer" directories through option `docker-lint` which default value is False to not introduce breaking changes.
- code-style docker linting can be tunned through options `docker-recursive` and `docker-error-level`.

docker-style
--------------

This action leverages the action [jbergstroem/hadolint-gh-action](https://github.com/jbergstroem/hadolint-gh-action) and requires a directory to look for the docker file. This directory can be anything but we emphasize to store docker files in a directory named "docker" at the root of the repository. If no "docker" directory exists, this action will raise a warning through the CI.

If one wants to evaluate multiple docker files nested in the provided directory, option `recursive` must be set to `True` and :warning: each file expected to be evaluated must be named Dockerfile. Notice that this constraints your repo to follow a directory oriented architecture, i.e. to split the Dockerfiles into multiple directories (e.g. docker/linux/Dockerfile and docker/windows/Dockerfile).

By default the action has a strict error level based on the outputs of [hadolint](https://github.com/hadolint/hadolint). Any info caught into this ouput will make the action failt. It can be lightened by changing the value of the option `error-level`. The associated value can be -1, 0, 1 or 2 where:
- -1: never fail;
- 0: fail on errors;
- 1: fail on warnings;
- 2: fail on infos.

code-style
------------

This action was modified to allow users to integrate docker linting (using previous docker-style action). By default this is not activated but one can activate it with option `docker-lint` set to True. Directory to be linted are set to "docker" and ".devcontainer", and the options used are `recursive=false` and `error-level=2`.
The options passed to the action "docker-style" can be modified through the new options `docker-recursive` and `docker-error-level`.

Notes
------

Github `working-directory` cannot be used with `uses` (I tried to use it to specify where to look for docker files).
At first we used [hadolint-action](https://github.com/hadolint/hadolint-action) but is wouldn't work as wanted when looking for multiple docker files. For example, if we wanted to look for multiple docker files, we would need to use the recursive option. However, if we wanted to look into an empty directory "docker" while having docker files in a directory "some_other_directory",  then the action would evaluate the docker files inside of "some_other_directory". Indeed, option `recursive` searches for specified dockerfile recursively, **from the project root**.

We also had to fix `hadolint-gh-action` issue through (https://github.com/jbergstroem/hadolint-gh-action/pull/135)