### PR TITLE
fix: docker directory check

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: "Install Git and clone project"
       uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
+      if: inputs.checkout == 'true'
 
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: "Install Git and clone project"
       uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
+      if: inputs.checkout == 'true'
 
     # ------------------------------------------------------------------------
 

--- a/docker-style/action.yml
+++ b/docker-style/action.yml
@@ -51,9 +51,21 @@ inputs:
     default: 2
     type: int
 
+  checkout:
+    description: >
+      Whether to clone the repository in the CI/CD machine. Default value is
+      ``true``.
+    default: true
+    required: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
+
+    - name: "Install Git and clone project"
+      uses: actions/checkout@v4
+      if: ${{ inputs.checkout == 'true' }}
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
Previous tests performed on `docker-style` were performed in a context where the repo was already cloned on the runner.
However, when that is not the case, the action does not run since there is nothing to lint and warning messages are raised for nothing (see https://github.com/ansys/pyansys-geometry/actions/runs/7869710413/job/21469384363)

This PR adds an extra step as in `doc-style` to trigger project clone if wanted (default is true).