### PR TITLE
fix: replace broken MIT link

### DIFF
--- a/.ci/ansys-actions/README.rst
+++ b/.ci/ansys-actions/README.rst
@@ -19,7 +19,7 @@ Pyactions core
    :alt: CI-CD
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
-   :target: https://opensource.org/licenses/MIT
+   :target: https://opensource.org/blog/license/mit
    :alt: MIT
 
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Ansys actions
    :alt: CI-CD
 
 .. |MIT| image:: https://img.shields.io/badge/License-MIT-blue.svg
-   :target: https://opensource.org/licenses/MIT
+   :target: https://opensource.org/blog/license/mit
    :alt: MIT
 
 A repository containing a collection of `GitHub Workflows


### PR DESCRIPTION
The link to the MIT license, https://opensource.org/licenses/MIT, is broken so I replaced it with https://opensource.org/blog/license/mit

Example of where it broke in a workflow: https://github.com/ansys/actions/actions/runs/7995412316/job/21835720195?pr=357#step:2:900