### PR TITLE
feat: new canonical link action

### DIFF
--- a/_doc-gen-canonical/action.yml
+++ b/_doc-gen-canonical/action.yml
@@ -1,0 +1,94 @@
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: >
+  Include and update canonical link tags in HTML pages of documentation.
+
+description: |
+  This process creates and updates the canonical link tags found in the HTML
+  documentation of a project. These tags are required to ensure that the pages
+  of hte documentation are indexed by web crawlers.
+
+inputs:
+
+  # Required inputs
+
+  cname:
+    description: >
+      The canonical name (CNAME) containing the documentation.
+    required: true
+    type: string
+
+  html-directory:
+    description: >
+      Name of the directory containing the HTML files of the website.
+    required: true
+    type: string
+
+
+runs:
+  using: "composite"
+  steps:
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Creating and updating required canonical link tags.
+
+    - name: "Generate the sitemap.xml file"
+      shell: bash
+      run: |
+
+        has_canonical_tag() {
+            local file=$1
+            grep -q "<link rel=\"canonical\" href=\"https://${{ inputs.cname }}/version/stable/" "$file"
+        }
+
+        add_canonical_tag() {
+            local file=$1
+            local filename=$(basename "$file")
+            local relative_path=${file#*version/*/}
+            local baseurl="https://{{ inputs.cname }}/version/stable"
+            local canonical_url="${baseurl}/${relative_path}"
+
+            if ! has_canonical_tag "${file}"; then
+                link_tag="\ \ <link rel=\"canonical\" href=\"$canonical_url\" />"
+                sed -i "/<\/head>/i$link_tag" "$file"
+                echo "Canonical link added to $file"
+            fi
+        }
+
+        export -f has_canonical_tag
+        export -f add_canonical_tag
+
+        find_html_files() {
+            local directory=$1
+            find "$directory" -type f -name "*.html" \
+                ! \( -name "announcement.html" -o -name "webpack-macros.html" \) \
+                -exec bash -c 'add_canonical_tag "$0"' {} \;
+        }
+
+        find_html_files ${{ inputs.html-directory }}
+

--- a/_doc-gen-canonical/action.yml
+++ b/_doc-gen-canonical/action.yml
@@ -64,7 +64,7 @@ runs:
         has_canonical_tag() {
             local file=$1
             grep -q "<link rel=\"canonical\" href=\"https://${{ inputs.cname }}/version/stable/" "$file"
-        }
+            }
 
         add_canonical_tag() {
             local file=$1

--- a/_doc-gen-canonical/action.yml
+++ b/_doc-gen-canonical/action.yml
@@ -26,7 +26,7 @@ name: >
 description: |
   This process creates and updates the canonical link tags found in the HTML
   documentation of a project. These tags are required to ensure that the pages
-  of hte documentation are indexed by web crawlers.
+  of the documentation are indexed by web crawlers.
 
 inputs:
 

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -214,6 +214,18 @@ runs:
           Copy the index.html from the stable version and update all
           local href and source links to point to either the stable or dev version.
 
+    - name: "Update the canonical link tags in the 'index.html' file"
+      shell: bash
+      run: |
+        if [[ -f 'version/stable/index.html' ]]; then
+          sed -i 's|<link rel="canonical" href="https://${{ inputs.cname }}/version/stable/|<link rel="canonical" href="https://${{ inputs.cname }}/|g' version/stable/index.html
+        elif [[ -f 'version/dev/index.html' ]]; then
+          sed -i 's|<link rel="canonical" href="https://${{ inputs.cname }}/version/dev/|<link rel="canonical" href="https://${{ inputs.cname }}/|g' version/dev/index.html
+        else
+          echo "Error: The 'index.html' file does not exist." >&2
+          exit 1
+        fi
+
     - name: "Use the latest 'index.html' in base index.html page"
       shell: bash
       run: |

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -468,6 +468,20 @@ runs:
       with:
         level: "INFO"
         message: >
+          Include a link canonical tag in old versions if not present.
+
+    - name: "Include link canonical tag in pages"
+      uses: ansys/actions/_doc-gen-canonical
+      with:
+        cname: ${{ inputs.cname }}
+        html-directory: version/stable
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
           For deploying the documentation, a GitHub token or a deployment token
           is required. The GitHub token is used when deploying to the current
           repository while the deployment token is used to deploy to an external

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -384,6 +384,18 @@ runs:
           Copy the index.html from the stable version and update all
           local href and source links to point to either the stable or dev version.
 
+    - name: "Update the canonical link tags in the 'index.html' file"
+      shell: bash
+      run: |
+        if [[ -f 'version/stable/index.html' ]]; then
+          sed -i 's|<link rel="canonical" href="https://${{ inputs.cname }}/version/stable/|<link rel="canonical" href="https://${{ inputs.cname }}/|g' version/stable/index.html
+        elif [[ -f 'version/dev/index.html' ]]; then
+          sed -i 's|<link rel="canonical" href="https://${{ inputs.cname }}/version/dev/|<link rel="canonical" href="https://${{ inputs.cname }}/|g' version/dev/index.html
+        else
+          echo "Error: The 'index.html' file does not exist." >&2
+          exit 1
+        fi
+
     - name: "Use the latest 'index.html' in base index.html page"
       shell: bash
       run: |


### PR DESCRIPTION
This pull-request includes a new reusable private action named `_doc-gen-canonical`. Its goal is to ensure that the `<link rel="canonical" href="..." />` is included in any HTML of the `version/stable` directory.