### PR TITLE
fix: Incorrect path in doc-changelog instructions

### DIFF
--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -74,7 +74,7 @@ or follow these steps:
 
 .. code:: md
 
-    This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/ansys/{repo-name}/tree/main/docs/changelog.d/>.
+    This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/ansys/{repo-name}/tree/main/doc/changelog.d/>.
 
     <!-- towncrier release notes start -->
 


### PR DESCRIPTION
The changelog had docs/changelog.d in its comment, but it should be doc/changelog.d