### PR TITLE
fix: doc-changelog action infinite loop with pre-commit.ci

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -187,10 +187,13 @@ runs:
         echo "${{ env.PR_TITLE }}"
         echo "${{ env.ORIGINAL_CONTENT }}"
 
-        # If the file was modified, commit & push it to the branch
-        if [[ ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
-          echo "modified: $modified"
-          # Commit and push fragment
-          git commit -m "Adding changelog entry: $fragment"
-          git push
+        # If the original content of the file is empty (no fragment file exists) or
+        # the file was modified and has different content from the original_content,
+        # commit & push the file to the branch
+        if [[ ! -z "${{ env.ORIGINAL_CONTENT }}" || ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
+            echo "modified: $modified"
+            # Commit and push fragment
+            git commit -m "Adding changelog entry: $fragment"
+            git push
+          fi
         fi

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -149,18 +149,13 @@ runs:
 
         # If the fragment file exists, then delete the file
         if [ ! -z "$file" ]; then
-          # Save content of original file
-          original_content=$(cat $file)
-          echo ORIGINAL_CONTENT='"'$original_content'"' >> $GITHUB_ENV
-
           echo "Removing $file"
           rm $file
-        else
-          echo ORIGINAL_CONTENT='"''"' >> $GITHUB_ENV
         fi
 
     - name: "Create and commit towncrier fragment"
       env:
+        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         PR_TITLE: "${{ github.event.pull_request.title }}"
         PR_NUMBER: ${{ github.event.number }}
       shell: bash
@@ -169,9 +164,12 @@ runs:
         # For example, 20.added.md
         fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
 
+        # Remove extra whitespace from PR title
+        clean_title=`echo ${{ env.PR_TITLE }} | xargs`
+
         # Create changelog fragment with towncrier
         # Fragment file contains the title of the PR
-        towncrier create -c "${{ env.PR_TITLE }}" $fragment
+        towncrier create -c "$clean_title" $fragment
 
         # Configure git username & email
         git config user.name 'pyansys-ci-bot'
@@ -183,12 +181,10 @@ runs:
         # Check if file was modified
         modified=`git diff HEAD --name-only`
 
-        # If the original content of the file is empty (no fragment file exists) or
-        # the file was modified and has different content from the original_content,
-        # commit & push the file to the branch
-        if [[ -z ${{ env.ORIGINAL_CONTENT }} || ! -z "$modified" && "${{ env.PR_TITLE }}" != *${{ env.ORIGINAL_CONTENT }}* ]]; then
-            echo "modified: $modified"
-            # Commit and push fragment
-            git commit -m "Adding changelog entry: $fragment"
-            git push
+        # If the file was modified, commit & push it to the branch
+        if [ ! -z "$modified" ]; then
+          echo "modified: $modified"
+          # Commit and push fragment
+          git commit -m "Adding changelog entry: $fragment"
+          git push
         fi

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -149,13 +149,18 @@ runs:
 
         # If the fragment file exists, then delete the file
         if [ ! -z "$file" ]; then
+          # Save content of original file
+          original_content=$(cat $file)
+          echo ORIGINAL_CONTENT='"'$original_content'"' >> $GITHUB_ENV
+
           echo "Removing $file"
           rm $file
+        else
+          echo ORIGINAL_CONTENT='"''"' >> $GITHUB_ENV
         fi
 
     - name: "Create and commit towncrier fragment"
       env:
-        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         PR_TITLE: "${{ github.event.pull_request.title }}"
         PR_NUMBER: ${{ github.event.number }}
       shell: bash
@@ -178,8 +183,11 @@ runs:
         # Check if file was modified
         modified=`git diff HEAD --name-only`
 
+        echo "${{ env.PR_TITLE }}"
+        echo "${{ env.ORIGINAL_CONTENT }}"
+
         # If the file was modified, commit & push it to the branch
-        if [ ! -z "$modified" ]; then
+        if [[ ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
           echo "modified: $modified"
           # Commit and push fragment
           git commit -m "Adding changelog entry: $fragment"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -190,7 +190,7 @@ runs:
         # If the original content of the file is empty (no fragment file exists) or
         # the file was modified and has different content from the original_content,
         # commit & push the file to the branch
-        if [[ ! -z "${{ env.ORIGINAL_CONTENT }}" || ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
+        if [[ -z "${{ env.ORIGINAL_CONTENT }}" || ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
             echo "modified: $modified"
             # Commit and push fragment
             git commit -m "Adding changelog entry: $fragment"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -156,7 +156,7 @@ runs:
           echo "Removing $file"
           rm $file
         else
-          echo ORIGINAL_CONTENT="" >> $GITHUB_ENV
+          echo ORIGINAL_CONTENT='"''"' >> $GITHUB_ENV
         fi
 
     - name: "Create and commit towncrier fragment"
@@ -183,14 +183,10 @@ runs:
         # Check if file was modified
         modified=`git diff HEAD --name-only`
 
-        echo "$modified"
-        echo "${{ env.PR_TITLE }}"
-        echo "${{ env.ORIGINAL_CONTENT }}"
-
         # If the original content of the file is empty (no fragment file exists) or
         # the file was modified and has different content from the original_content,
         # commit & push the file to the branch
-        if [[ -z "${{ env.ORIGINAL_CONTENT }}" || ! -z "$modified" && "${{ env.PR_TITLE }}" != *"${{ env.ORIGINAL_CONTENT }}"* ]]; then
+        if [[ -z ${{ env.ORIGINAL_CONTENT }} || ! -z "$modified" && "${{ env.PR_TITLE }}" != *${{ env.ORIGINAL_CONTENT }}* ]]; then
             echo "modified: $modified"
             # Commit and push fragment
             git commit -m "Adding changelog entry: $fragment"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -195,5 +195,4 @@ runs:
             # Commit and push fragment
             git commit -m "Adding changelog entry: $fragment"
             git push
-          fi
         fi

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -156,7 +156,7 @@ runs:
           echo "Removing $file"
           rm $file
         else
-          echo ORIGINAL_CONTENT='"''"' >> $GITHUB_ENV
+          echo ORIGINAL_CONTENT="" >> $GITHUB_ENV
         fi
 
     - name: "Create and commit towncrier fragment"
@@ -183,6 +183,7 @@ runs:
         # Check if file was modified
         modified=`git diff HEAD --name-only`
 
+        echo "$modified"
         echo "${{ env.PR_TITLE }}"
         echo "${{ env.ORIGINAL_CONTENT }}"
 


### PR DESCRIPTION
Trailing whitespace in the title caused an infinite loop between the changelog action and pre-commit.ci fixing the fragment file by removing the trailing whitespace. This fix uses xargs to remove extra whitespace in the PR title

1. Fragment file is added to the PR https://github.com/ansys/pymechanical/actions/runs/8483508864/job/23244782632?pr=669
2. Merged in main & fragment file wasn't updated https://github.com/ansys/pymechanical/actions/runs/8483553847/job/23244904355?pr=669
3. Title changed (still contains trailing whitespace) & fragment file updated: https://github.com/ansys/pymechanical/actions/runs/8483590918/job/23245005569?pr=669

Closes #436 