### PR TITLE
fix: changelog action backtick in title

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -165,7 +165,7 @@ runs:
         fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
 
         # Remove extra whitespace from PR title
-        clean_title=`echo ${{ env.PR_TITLE }} | xargs`
+        clean_title=$(echo ${{ env.PR_TITLE }} | xargs)
 
         # Create changelog fragment with towncrier
         # Fragment file contains the title of the PR

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -165,7 +165,7 @@ runs:
         fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
 
         # Remove extra whitespace from PR title
-        clean_title=$(echo ${{ env.PR_TITLE }} | xargs)
+        clean_title=$(echo '${{ env.PR_TITLE }}' | xargs)
 
         # Create changelog fragment with towncrier
         # Fragment file contains the title of the PR

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -156,7 +156,7 @@ runs:
     - name: "Create and commit towncrier fragment"
       env:
         PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        PR_TITLE: "${{ github.event.pull_request.title }}"
+        PR_TITLE: '${{ github.event.pull_request.title }}'
         PR_NUMBER: ${{ github.event.number }}
       shell: bash
       run: |


### PR DESCRIPTION
Backticks in titles were erased in the changelog fragment file & also caused infinite loops in pyansys-geometry

Correctly detects backticks: [test with `backticks` · ansys/pymechanical@c007805 (github.com)](https://github.com/ansys/pymechanical/actions/runs/8509562415/job/23306827024?pr=671)

Correctly detects backticks and extra whitespace: [test with `backticks` and extra spaces · ansys/pymechanical@6bd46c1 (github.com)](https://github.com/ansys/pymechanical/actions/runs/8510073370/job/23306905123?pr=671)