### PR TITLE
refactor: way to retrieve pull request title

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -153,10 +153,27 @@ runs:
           rm $file
         fi
 
+    - name: "Retrieve PR title"
+      env:
+        REPOSITORY_OWNER: ${{ github.repository_owner }}
+        REPOSITORY_NAME: ${{ github.event.repository.name }}
+        PULL_REQUEST_NUMBER: ${{ github.event.number }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const response = await github.graphql(`query {
+            repository(owner: "${{ env.REPOSITORY_OWNER }}", name: "${{ env.REPOSITORY_NAME }}") {
+              pullRequest(number: ${{ env.PULL_REQUEST_NUMBER }}) {
+                title
+              }
+            }
+          }`)
+          const title = response.repository.pullRequest.title;
+          core.exportVariable('PR_TITLE', title);
+
     - name: "Create and commit towncrier fragment"
       env:
         PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        PR_TITLE: '${{ github.event.pull_request.title }}'
         PR_NUMBER: ${{ github.event.number }}
       shell: bash
       run: |


### PR DESCRIPTION
Retrieving a pull request title was performed through `${{ github.event.pull_request.title }}`. However, this works correctly with edited titles only if you specify that your workflow is triggered on PR edition, e.g.
```
pull_request:
    types: [opened, reopened, synchronize, edited]
```

Since it causes other jobs to be also triggered, I propose another approach to retrieve the PR title. This will allow one to retrigger manually the changelog action after a title change, without rerunning the whole workflow.

Overall I would say that it improves a bit the flexibility of the action. However, if one wants to keep the fact that editing the PR title triggers automatically the job, then one will have to keep using the mentioned scope activation (`edited`). 

Closes #443 