### PR TITLE
feat: allow upper case in commit-style

### DIFF
--- a/commit-style/action.yml
+++ b/commit-style/action.yml
@@ -38,12 +38,47 @@ inputs:
     required: true
     type: string
 
+  # Optional inputs
+
+  use-upper-case:
+    description: >
+      Use of uppercase letters in the "type" and "scope" fields of the commit.
+      For example, "FIX(SERVER)!: fix server crash issue" would be a valid commit.
+
+      .. note::
+
+          Expected type are upper cases of `conventional commit types
+          <https://github.com/commitizen/conventional-commit-types/blob/master/index.json>`_.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
 
     - name: "Check pull-request title follows conventional commits style"
-      if: ${{ (github.event_name == 'pull_request_target') || (github.event_name == 'pull_request') }}
+      if: ${{ ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && inputs.use-upper-case == 'false' }}
       uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+
+    - name: "Check pull-request title follows conventional commits style with upper case"
+      if: ${{ ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && inputs.use-upper-case == 'true' }}
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        types: |
+          BUILD
+          CHORE
+          CI
+          DOCS
+          FEAT
+          FIX
+          PERF
+          REFACTOR
+          REVERT
+          STYLE
+          TEST
+

--- a/commit-style/action.yml
+++ b/commit-style/action.yml
@@ -49,6 +49,7 @@ inputs:
 
           Expected type are upper cases of `conventional commit types
           <https://github.com/commitizen/conventional-commit-types/blob/master/index.json>`_.
+
     required: false
     default: false
     type: boolean


### PR DESCRIPTION
As title says.

Closes #446

Note: option `headerPattern` seems to be related to "how to parse" a commit title to retrieve the `type`, `scope` and `description`. Thus it seems more adequate to use option `types` instead.