### PR TITLE
feat: ignore pre-commit.ci branch name on branch-name-style action

### DIFF
--- a/branch-name-style/action.yml
+++ b/branch-name-style/action.yml
@@ -51,6 +51,12 @@ runs:
       run: |
         branch_name=${{ github.head_ref || github.ref }}
 
+        # Ignore pre-commit.ci branch name
+        if [[ $branch_name == "pre-commit-ci-update-config" ]]; then
+          echo "\033[1;92m[INFO]: Branch name is pre-commit-ci-update-config. Skipping branch name check."
+          exit 0
+        fi
+
         if [[ $branch_name != */* ]]; then
           echo "\033[1;91m[ERROR]: Branch name $branch_name does not contain a prefix and a backslash." >&2
           exit 1


### PR DESCRIPTION
This action is otherwise incompatible with projects using pre-commit.ci.

Workaround is https://github.com/ansys/pyansys-geometry/pull/1108 but I would rather have it skipped by the action directly since it affects multiple projects.