### PR TITLE
fix: wrong action version in doc-build

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -170,7 +170,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@feat/doc-build-os-compatible
+      uses: ansys/actions/_doc-build-linux@main
       with:
         python-version: ${{ inputs.python-version }}
         use-python-cache: ${{ inputs.use-python-cache }}
@@ -196,7 +196,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@feat/doc-build-os-compatible
+      uses: ansys/actions/_doc-build-windows@main
       with:
         python-version: ${{ inputs.python-version }}
         use-python-cache: ${{ inputs.use-python-cache }}


### PR DESCRIPTION
Seems like #453 got merged before I could change the version it was pointing to. It was left pointing to the development branch to let anyone test the action on their repo as it was performed in https://github.com/ansys/pyansys-geometry/pull/1068.

I should have left a warning to notify of that, sorry for not thinking about it.