### PR TITLE
docs: add package phrase replacement example in doc-changelog guide

### DIFF
--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -9,6 +9,7 @@ or follow these steps:
 
 
 1. Add the following lines to the ``pyproject.toml`` file, replacing ``{repo-name}`` with the name of the repository. For example, ``pyansys-geometry``.
+Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.module``. For example, ``ansys.geometry.core``.
 
 .. code:: toml
 


### PR DESCRIPTION
Adding an example for how to replace `"ansys.<product>.<library>"` in the doc-changelog migration guide