### PR TITLE
fix: regex for fixing links in landing page

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -233,12 +233,12 @@ runs:
       run: |
         if [[ -f 'version/stable/index.html' ]]; then
           cp version/stable/index.html index.html
-          sed -i 's/href="\([^http]\)/href="version\/stable\/\1/g' index.html
-          sed -i 's/src="\([^http]\)/src="version\/stable\/\1/g' index.html
+          sed -i 's/href="\([^:"]*\)"/href="version\/stable\/\1"/g' index.html
+          sed -i 's/src="\([^:"]*\)"/src="version\/stable\/\1"/g' index.html
         elif [[ -f 'version/dev/index.html' ]]; then
           cp version/dev/index.html index.html
-          sed -i 's/href="\([^http]\)/href="version\/dev\/\1/g' index.html
-          sed -i 's/src="\([^http]\)/src="version\/dev\/\1/g' index.html
+          sed -i 's/href="\([^:"]*\)"/href="version\/dev\/\1"/g' index.html
+          sed -i 's/src="\([^:"]*\)"/src="version\/dev\/\1"/g' index.html
         else
           echo "Error: The 'index.html' file does not exist." >&2
           exit 1

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -403,12 +403,12 @@ runs:
       run: |
         if [[ -f 'version/stable/index.html' ]]; then
           cp version/stable/index.html index.html
-          sed -i 's/href="\([^http]\)/href="version\/stable\/\1/g' index.html
-          sed -i 's/src="\([^http]\)/src="version\/stable\/\1/g' index.html
+          sed -i 's/href="\([^:"]*\)"/href="version\/stable\/\1"/g' index.html
+          sed -i 's/src="\([^:"]*\)"/src="version\/stable\/\1"/g' index.html
         elif [[ -f 'version/dev/index.html' ]]; then
           cp version/dev/index.html index.html
-          sed -i 's/href="\([^http]\)/href="version\/dev\/\1/g' index.html
-          sed -i 's/src="\([^http]\)/src="version\/dev\/\1/g' index.html
+          sed -i 's/href="\([^:"]*\)"/href="version\/dev\/\1"/g' index.html
+          sed -i 's/src="\([^:"]*\)"/src="version\/dev\/\1"/g' index.html
         else
           echo "Error: The 'index.html' file does not exist." >&2
           exit 1


### PR DESCRIPTION
Fixes the issues originated when a local link starts with `h`, or `t`, or `p`.