### PR TITLE
fix: order of checkout and Python install has to be reversed

### DIFF
--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -156,15 +156,15 @@ runs:
 
     # --------------- Common to linux and windows doc-build ----------------
 
+    - name: "Install Git and clone project"
+      uses: actions/checkout@v4
+      if: ${{ inputs.checkout == 'true' }}
+
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
-
-    - name: "Install Git and clone project"
-      uses: actions/checkout@v4
-      if: ${{ inputs.checkout == 'true' }}
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #461 

Order was inverted... leading to incapability to cache deps