### PR TITLE
docs: update v6 changes

### DIFF
--- a/commit-style/action.yml
+++ b/commit-style/action.yml
@@ -42,8 +42,8 @@ inputs:
 
   use-upper-case:
     description: >
-      Use of uppercase letters in the "type" and "scope" fields of the commit.
-      For example, "FIX(SERVER)!: fix server crash issue" would be a valid commit.
+      Use of uppercase letters in the "type" field of the commit.
+      For example, "FIX!: fix server crash issue" would be a valid commit.
 
       .. note::
 

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -43,6 +43,13 @@ Version ``v6``
   - Generation of `sitemap.xml` file for quicker indexing of `version/stable/` pages
   - Inclusion of `canonical` link tags in all HTML files for SEO purposes
 
+- Extend ``ansys/actions/doc-build`` to be able to run in Windows runners.
+  To buid the documentation in a Windows runner, we install ``Chocolatey`` and ``Miktex``.
+
+- Allow ``ansys/actions/commit-style`` to work with upper case in the type field of a commit.
+  Expected types are upper cases of  `conventional commit types
+  <https://github.com/commitizen/conventional-commit-types/blob/master/index.json>`_.
+
 **Breaking changes:**
 
 - Upgrade default ``vale`` version from ``2.29.6`` to ``3.4.1`` in ``ansys/actions/doc-style`` action.


### PR DESCRIPTION
Changes include a minor patch for the documentation of `commit-style` and updates the new features of `v6`.