### PR TITLE
fix: fail doc-style action when wrong Vale config is present

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -89,14 +89,14 @@ runs:
       shell: bash
       run: |
         if [ $VALE_MAJOR_VERSION -ge 3 ]; then
-          if [ ! -d ./doc/styles/config/vocabularies/ANSYS ]; then
-            echo "Projects using Vale >=v3 require a doc/styles/config/vocabularies/ANSYS directory."
+          if [ ! -d ./doc/styles/config/vocabularies ]; then
+            echo "Projects using Vale >=v3 require a doc/styles/config/vocabularies directory."
             echo "See migration guide https://actions.docs.ansys.com/version/stable/migrations/docs-style-vale-version-update.html"
             exit 1
           fi
         else
-          if [ ! -d ./doc/styles/Vocab/ANSYS ]
-            echo "Projects using Vale <=v2 require a doc/styles/Vocab/ANSYS directory. Consider updating your Vale version to v3."
+          if [ ! -d ./doc/styles/Vocab ]
+            echo "Projects using Vale <=v2 require a doc/styles/Vocab directory. Consider updating your Vale version to v3."
             echo "See migration guide https://actions.docs.ansys.com/version/stable/migrations/docs-style-vale-version-update.html"
             exit 1
           fi

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -71,6 +71,37 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout == 'true'
 
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Ensure Vale configuration follows the right layout for the specified
+          version of Vale.
+
+    - name: "Check Vale's version"
+      shell: bash
+      run: |
+        version=${{ inputs.vale-version }}
+        vale_major_version=$( echo $version | cut -d '.' -f 1)
+        echo "VALE_MAJOR_VERSION=$(echo $major)" >> $GITHUB_ENV
+
+    - name: "Verify Vale's configuration layout according to selected version"
+      shell: bash
+      run: |
+        if [ $VALE_MAJOR_VERSION -ge 3 ]; then
+          if [ ! -d ./doc/styles/config/vocabularies/ANSYS ]; then
+            echo "Projects using Vale >=v3 require a doc/styles/config/vocabularies/ANSYS directory."
+            echo "See migration guide https://actions.docs.ansys.com/version/stable/migrations/docs-style-vale-version-update.html"
+            exit 1
+          fi
+        else
+          if [ ! -d ./doc/styles/Vocab/ANSYS ]
+            echo "Projects using Vale <=v2 require a doc/styles/Vocab/ANSYS directory. Consider updating your Vale version to v3."
+            echo "See migration guide https://actions.docs.ansys.com/version/stable/migrations/docs-style-vale-version-update.html"
+            exit 1
+          fi
+        fi
+
     - name: "Run Vale"
       uses: errata-ai/vale-action@reviewdog
       env:


### PR DESCRIPTION
As per a private discussion, we are forcing the `doc-style` action to check the Vale configuration layout according to the selected version.