### PR TITLE
fix: canonical link injection in HTML files

### DIFF
--- a/_doc-gen-canonical/action.yml
+++ b/_doc-gen-canonical/action.yml
@@ -73,7 +73,7 @@ runs:
             local baseurl="https://${{ inputs.cname }}/version/stable"
             local canonical_url="${baseurl}/${relative_path}"
             local link_tag="\ \ <link rel=\"canonical\" href=\"$canonical_url\" />"
-            sed -i "/<\/head>/i$link_tag" "$file"
+            sed -i "/^ *<\/head>/i$link_tag" "$file"
             echo "Canonical link added to $file"
         }
 


### PR DESCRIPTION
This pull-request ensures the canonical link gets added right before the main `</head>`.