### PR TITLE
feat: enable validate-build option to build-library action

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -60,7 +60,14 @@ inputs:
       Whether to use the Python cache for installing previously downloaded
       libraries. If ``true``, previously downloaded libraries are installed from the
       Python cache. If ``false``, libraries are downloaded from the PyPI index.
+    required: false
+    default: true
+    type: boolean
 
+  validate-build:
+    description: >
+      Whether to validate the build process. If ``true``, the build process is
+      validated. If ``false``, the build process is not validated.
     required: false
     default: true
     type: boolean
@@ -83,10 +90,16 @@ runs:
       run: |
         python -m pip install build twine
 
-    - name: "Build distribution artifacts and check their health"
+    - name: "Build distribution artifacts"
       shell: bash
       run: |
-        python -m build && python -m twine check dist/*
+        python -m build
+
+    - name: "Check build health"
+      shell: bash
+      if: inputs.validate-build == 'true'
+      run: |
+        python -m twine check dist/*
 
     - name: "Upload distribution artifacts to GitHub artifacts"
       uses: actions/upload-artifact@v4

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -12,6 +12,10 @@ Development version
 
 **New features:**
 
+- Added an optional input to the ``ansys/actions/build-library`` action to disable library build
+  validation on demand using the ``validate-build: false`` argument. This is useful when you want to
+  skip the library build validation step in the action.
+
 **Breaking changes:**
 
 **Migration steps:**

--- a/doc/styles/.gitignore
+++ b/doc/styles/.gitignore
@@ -1,4 +1,6 @@
-/*
-!**/ANSYS/accept.txt
-!**/ANSYS/reject.txt
+*
+!config
+!config/vocabularies
+!config/vocabularies/ANSYS
+!config/vocabularies/ANSYS/**
 !.gitignore


### PR DESCRIPTION
As title says. Coming from an internal request by @anscfrisson. Some libraries may have long descriptions that are causing the twine check to validate. These libraries will never be published to PyPI in this state (since PyPI upload will probably fail). However it will allow them to continue to build the library using our actions.