### PR TITLE
fix: check pyproject.toml file exists before opening it

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,7 +117,7 @@ jobs:
     needs: commit-and-branch-style
     steps:
       - name: "Run documentation style checks"
-        uses: ansys/actions/doc-style@main
+        uses: ansys/actions/doc-style@fix/file-dne
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -133,15 +133,18 @@ runs:
         import os
         import toml
 
-        # Load pyproject.toml
-        with open('pyproject.toml', 'r') as f:
-            config = toml.load(f)
-            try:
-                # Get towncrier directory
-                directory=config["tool"]["towncrier"]["directory"]
-            except KeyError:
-                # If towncrier directory isn't specified in pyproject.toml
-                directory=""
+        if os.path.exists("pyproject.toml"):
+          # Load pyproject.toml
+          with open('pyproject.toml', 'r') as f:
+              config = toml.load(f)
+              try:
+                  # Get towncrier directory
+                  directory=config["tool"]["towncrier"]["directory"]
+              except KeyError:
+                  # If towncrier directory isn't specified in pyproject.toml
+                  directory=""
+        else:
+            directory=""
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -134,15 +134,15 @@ runs:
         import toml
 
         if os.path.exists("pyproject.toml"):
-          # Load pyproject.toml
-          with open('pyproject.toml', 'r') as f:
-              config = toml.load(f)
-              try:
-                  # Get towncrier directory
-                  directory=config["tool"]["towncrier"]["directory"]
-              except KeyError:
-                  # If towncrier directory isn't specified in pyproject.toml
-                  directory=""
+            # Load pyproject.toml
+            with open('pyproject.toml', 'r') as f:
+                config = toml.load(f)
+                try:
+                    # Get towncrier directory
+                    directory=config["tool"]["towncrier"]["directory"]
+                except KeyError:
+                    # If towncrier directory isn't specified in pyproject.toml
+                    directory=""
         else:
             directory=""
 


### PR DESCRIPTION
doc-style fails in main if pyproject.toml doesn't exist in the repository