### PR TITLE
feat: make optional use latest index in landing page

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -107,6 +107,14 @@ inputs:
     required: false
     default: 'main-content'
     type: string
+  
+  use-latest-index-in-landing-page:
+    description: >
+      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default 
+      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html. 
+    required: false
+    default: true
+    type: string
 
 runs:
   using: "composite"
@@ -255,6 +263,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: ${{ inputs.use-latest-index-in-landing-page == 'true' }}
       with:
         level: "INFO"
         message: >
@@ -263,6 +272,7 @@ runs:
 
     - name: "Use the latest 'version/{stable|dev}/index.html' in the landing page"
       shell: bash
+      if: ${{ inputs.use-latest-index-in-landing-page == 'true' }}
       run: |
         if [[ -f 'version/stable/index.html' ]]; then
           cp version/stable/index.html index.html
@@ -280,7 +290,12 @@ runs:
     - name: "Show the contents of the 'index.html' redirection file"
       shell: bash
       run: |
+        if [[ -f 'index.html' ]]; then
           cat index.html
+        else
+          echo "Error: The 'index.html' file does not exist." >&2
+          exit 1
+        fi
 
     # ------------------------------------------------------------------------
 

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -107,11 +107,11 @@ inputs:
     required: false
     default: 'main-content'
     type: string
-  
+
   use-latest-index-in-landing-page:
     description: >
-      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default 
-      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html. 
+      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default
+      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html.
     required: false
     default: true
     type: string

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -109,7 +109,7 @@ inputs:
     type: string
 
   use-latest-index-in-landing-page:
-    description: >
+    description: |
       Use the latest 'version/{stable|dev}/index.html' in the landing page. Default
       value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html.
     required: false

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -131,6 +131,14 @@ inputs:
     default: false
     type: boolean
 
+  use-latest-index-in-landing-page:
+    description: >
+      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default 
+      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html. 
+    required: false
+    default: true
+    type: string
+
 runs:
   using: "composite"
   steps:
@@ -423,6 +431,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: ${{ inputs.use-latest-index-in-landing-page == 'true' }}
       with:
         level: "INFO"
         message: >
@@ -430,6 +439,7 @@ runs:
           local href and source links to point to either the stable or dev version.
 
     - name: "Use the latest 'version/{stable|dev}/index.html' in the landing page"
+      if: ${{ inputs.use-latest-index-in-landing-page == 'true' }}
       shell: bash
       run: |
         if [[ -f 'version/stable/index.html' ]]; then
@@ -448,7 +458,12 @@ runs:
     - name: "Show the contents of the 'index.html' redirection file"
       shell: bash
       run: |
+        if [[ -f 'index.html' ]]; then
           cat index.html
+        else
+          echo "Error: The 'index.html' file does not exist." >&2
+          exit 1
+        fi
 
     # ------------------------------------------------------------------------
 

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -133,8 +133,8 @@ inputs:
 
   use-latest-index-in-landing-page:
     description: >
-      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default 
-      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html. 
+      Use the latest 'version/{stable|dev}/index.html' in the landing page. Default
+      value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html.
     required: false
     default: true
     type: string

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -132,7 +132,7 @@ inputs:
     type: boolean
 
   use-latest-index-in-landing-page:
-    description: >
+    description: |
       Use the latest 'version/{stable|dev}/index.html' in the landing page. Default
       value is ``true``. By default, the index.html is overwritten by version/{stable|dev}/index.html.
     required: false


### PR DESCRIPTION
In this PR, I added an input to `doc-deploy-dev` and `doc-deploy-stable` so we can skip when needed the step to overwrite the index.html page. 

It will be used in some internal projects.

Tested [here](https://github.com/ansys-internal/glow-engine/actions/runs/9220336792) successfully.

_** Correct the name of the branch used in [PR#492](https://github.com/ansys/actions/pull/492)_