### PR TITLE
fix: update doc deploy actions to to correct local search path on landing page

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -278,10 +278,12 @@ runs:
           cp version/stable/index.html index.html
           sed -i 's/href="\([^:"]*\)"/href="version\/stable\/\1"/g' index.html
           sed -i 's/src="\([^:"]*\)"/src="version\/stable\/\1"/g' index.html
+          sed -i 's/action="search.html"/action="version\/stable\/search.html"/g' index.html
         elif [[ -f 'version/dev/index.html' ]]; then
           cp version/dev/index.html index.html
           sed -i 's/href="\([^:"]*\)"/href="version\/dev\/\1"/g' index.html
           sed -i 's/src="\([^:"]*\)"/src="version\/dev\/\1"/g' index.html
+          sed -i 's/action="search.html"/action="version\/dev\/search.html"/g' index.html
         else
           echo "Error: The 'index.html' file does not exist." >&2
           exit 1

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -446,10 +446,12 @@ runs:
           cp version/stable/index.html index.html
           sed -i 's/href="\([^:"]*\)"/href="version\/stable\/\1"/g' index.html
           sed -i 's/src="\([^:"]*\)"/src="version\/stable\/\1"/g' index.html
+          sed -i 's/action="search.html"/action="version\/stable\/search.html"/g' index.html
         elif [[ -f 'version/dev/index.html' ]]; then
           cp version/dev/index.html index.html
           sed -i 's/href="\([^:"]*\)"/href="version\/dev\/\1"/g' index.html
           sed -i 's/src="\([^:"]*\)"/src="version\/dev\/\1"/g' index.html
+          sed -i 's/action="search.html"/action="version\/dev\/search.html"/g' index.html
         else
           echo "Error: The 'index.html' file does not exist." >&2
           exit 1


### PR DESCRIPTION
This PR addresses a search issue in the deployment script by updating the search action path in the landing page. Previously, the search action was set to `search.html`, causing search functionality to look for the incorrect file. With this fix, the search action path is updated to `version/stable/search.html` for stable versions or `version/dev/search.html` for development versions. This ensures that the search functionality points to the correct location, resolving the search issue effectively.