### PR TITLE
chore: enhance doc-changelog migration guide

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -83,6 +83,22 @@ inputs:
     default: true
     type: boolean
 
+  use-upper-case:
+    description: >
+      Use of uppercase letters in the "type" field of:
+
+      - The PR created into main to add CHANGELOG changes.
+
+      - The commit created in the release branch to add the new
+        section in CHANGELOG.
+
+
+      If ``false``, the title is "chore: ... CHANGELOG for v...".
+      If ``true``, the title is "CHORE: ... CHANGELOG for v...".
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -201,7 +217,11 @@ runs:
           git add .
 
           # Commit changes and save commit SHA
-          git commit -m "Updating CHANGELOG for v${{ env.TAG_VERSION }}"
+          if [[ ${{ inputs.use-upper-case }} == "false" ]] ; then
+            git commit -m "chore: updating CHANGELOG for v${{ env.TAG_VERSION }}"
+          else
+            git commit -m "CHORE: updating CHANGELOG for v${{ env.TAG_VERSION }}"
+          fi
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
           # Push CHANGELOG.md changes
@@ -268,7 +288,12 @@ runs:
         # Push CHANGELOG.md changes to $pr_branch
         git push -u origin $pr_branch
 
-        gh pr create --title "chore: update CHANGELOG for v${{ env.TAG_VERSION }}" --body "Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}" --reviewer ${{ github.actor }}
+        if [[ ${{ inputs.use-upper-case }} == "false" ]] ; then
+          pr_title="chore: update CHANGELOG for v${{ env.TAG_VERSION }}"
+        else
+          pr_title="CHORE: update CHANGELOG for v${{ env.TAG_VERSION }}"
+        fi
+        gh pr create --title "$pr_title" --body "Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}" --reviewer ${{ github.actor }}
 
     - name: "Delete & Re-create tag"
       env:

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -40,8 +40,6 @@ At the end of the ``.github/workflows/label.yml`` file, add the following lines 
           with:
             token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
 
-|
-
 Next, follow the instructions to create release notes in your `documentation <#include-the-release-notes-in-your-documentation>`_ or `CHANGELOG.md file <#include-the-release-notes-in-changelog-md>`_ depending on your preference.
 
 Include the release notes in your documentation
@@ -68,8 +66,6 @@ Include the release notes in your documentation
 
 
     {% endif %}
-
-|
 
 2. Create a new file named ``changelog.rst`` in the ``doc/source`` directory. Add the following lines to the file:
 
@@ -98,8 +94,6 @@ Include the release notes in your documentation
         This document contains the release notes for the project. See release notes for v{latest-version} and earlier
         in `CHANGELOG.md <https://github.com/{org-name}/{repo-name}/blob/main/CHANGELOG.md>`_.
 
-|
-
 3. Add ``changelog`` to the toctree list in the ``doc/source/index.rst`` file. ``changelog`` is placed last in the ``toctree`` list, so the "Release notes" tab is last in the documentation.
 
 .. code:: rst
@@ -110,8 +104,6 @@ Include the release notes in your documentation
 
        <other files>
        changelog
-
-|
 
 4. Add the following lines to the ``doc/source/conf.py`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively:
 
@@ -135,8 +127,6 @@ Include the release notes in your documentation
 
       release = version = __version__
       switcher_version = get_version_match(version)
-
-|
 
 5. Add the following lines to the ``pyproject.toml`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively.
 Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.module``. For example, ``ansys.geometry.core``.
@@ -190,10 +180,8 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
         This project uses [towncrier](https://towncrier.readthedocs.io/). Changes for the upcoming release can be found in
         [changelog.rst](doc/source/changelog.rst).
 
-|
-
 Reference pull requests for the changes can be found in the `PyAnsys Geometry <https://github.com/ansys/pyansys-geometry/pull/1138>`_ and `PyMechanical <https://github.com/ansys/pymechanical/pull/757/files>`_ repositories.
-The PyAnsys-Geometry pull request includes some other changes, but the changelog implementation is the same as described in this document.
+The `PyAnsys Geometry`_ pull request includes some other changes, but the changelog implementation is the same as described in this document.
 
 Include the release notes in ``CHANGELOG.md``
 ---------------------------------------------
@@ -218,8 +206,6 @@ Include the release notes in ``CHANGELOG.md``
 
     {% endif %}
 
-|
-
 2. Add the following lines to the ``CHANGELOG.md`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively:
 
 .. code:: md
@@ -239,8 +225,6 @@ Include the release notes in ``CHANGELOG.md``
         <!-- towncrier release notes start -->
 
         ## [0.10.7](https://github.com/ansys/pymechanical/releases/tag/v0.10.7) - February 13 2024
-
-|
 
 3. Add the following lines to the ``pyproject.toml`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively.
 Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.module``. For example, ``ansys.geometry.core``.
@@ -282,9 +266,7 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
     name = "Miscellaneous"
     showcontent = true
 
-|
-
-A reference pull request for these changes can be found in the `PyAnsys-Geometry <https://github.com/ansys/pyansys-geometry/pull/1023/files>`_ repository.
+A reference pull request for these changes can be found in the `PyAnsys Geometry #1023 <https://github.com/ansys/pyansys-geometry/pull/1023/files>`_ pull request.
 
 
 ``towncrier`` commands
@@ -314,9 +296,8 @@ Create a changelog file manually:
 
         - Added a feature [#1](https://github.com/ansys/{repo-name}/pull/1)
 
-|
-
-When you are ready to do a release for your repository, run the following command to
+When you are ready to do a release for your repository, set up the ``ansys/actions/doc-deploy-changelog`` action
+to automate the process of generating the changelog. If you want to do it manually, run the following command to
 update the ``CHANGELOG.md`` file with the files in the ``changelog.d`` directory, replacing ``{version}`` with your
 release number. For example, ``0.10.8``. Do not include "v" in the version:
 
@@ -324,15 +305,11 @@ release number. For example, ``0.10.8``. Do not include "v" in the version:
 
     towncrier build --yes --version {version}
 
-|
-
 If you want to update the ``CHANGELOG.md`` file but keep the files in the ``changelog.d`` directory, run this command:
 
 .. code:: bash
 
     towncrier build --keep --version {version}
-
-|
 
 If you only want to preview the changelog and not make changes to the ``CHANGELOG.md`` file,
 run the following command:

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -3,8 +3,13 @@
 Doc-changelog action setup
 ==========================
 
-To set up your repository to use the ``ansys/actions/doc-changelog`` action, see
-`changelog implementation in PyAnsys-Geometry <https://github.com/ansys/pyansys-geometry/pull/1023/files>`_
+To set up your repository to use the ``ansys/actions/doc-changelog`` action, you can choose to have the release notes in your
+repository or documentation. 
+
+Implementing the changelog as part of your repository
+-----------------------------------------------------
+
+See the `changelog implementation in PyAnsys-Geometry <https://github.com/ansys/pyansys-geometry/pull/1023/files>`_
 or follow these steps:
 
 
@@ -123,15 +128,14 @@ At the end of the ``.github/workflows/label.yml`` file, add the following lines 
           with:
             token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
 
-
 Implementing the changelog as part of your documentation
 --------------------------------------------------------
 
 The previous steps set up the changelog for your repository. To implement the changelog in your documentation,
 some modifications have to be performed. Based on the PyAnsys libraries standards, this section assumes that
-the repository has a ``docs`` directory with a Sphinx documentation setup.
+the repository has a ``doc`` directory with a Sphinx documentation setup.
 
-1. Create a new file named ``changelog.rst`` in the ``docs`` directory. Add the following lines to the file:
+1. Create a new file named ``changelog.rst`` in the ``doc/source`` directory. Add the following lines to the file:
 
 .. code:: rst
 
@@ -149,7 +153,14 @@ the repository has a ``docs`` directory with a Sphinx documentation setup.
 
     .. vale on
 
-2. Add the ``changelog.rst`` file to the ``index.rst`` file in the ``docs`` directory.
+If your project previously used ``CHANGELOG.md`` to record the release notes, change the description under "Release notes". Replace ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively, and ``{latest-version}`` with the most recent version in your ``CHANGELOG.md`` file::
+
+  .. code:: rst
+
+    This document contains the release notes for the project. See release notes for v{latest-version} or earlier in `CHANGELOG.md <https://github.com/{org-name}/{repo-name}/blob/main/CHANGELOG.md>`_.
+  
+
+2. Add ``changelog`` to the toctree list in the ``doc/source/index.rst`` file. ``changelog`` is placed last in the ``toctree`` list, so the "Release notes" tab is last in the documentation. 
 
 .. code:: rst
 
@@ -157,12 +168,11 @@ the repository has a ``docs`` directory with a Sphinx documentation setup.
        :hidden:
        :maxdepth: 3
 
-       changelog
        <other files>
+       changelog
 
 
-3. Add the following lines to the ``conf.py`` file in the ``docs`` directory, replacing ``{repo-name}``
-   and ``{org-name}`` with the name of the repository:
+3. Add the following lines to the ``doc/source/conf.py`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively:
 
 .. code:: python
 
@@ -173,8 +183,19 @@ the repository has a ``docs`` directory with a Sphinx documentation setup.
             f"https://github.com/{org-name}/{repo-name}/releases/tag/v{__version__}"
         )
 
-4. Modify the ``pyproject.toml`` file to include the following lines, replacing ``{repo-name}``
-   and ``{org-name}`` with the name of the repository:
+.. note::
+
+  This assumes the following code already exists in the ``doc/source/conf.py`` file:
+
+  .. code:: python
+
+      from ansys_sphinx_theme import get_version_match
+      from ansys.<product>.<library> import __version__
+    
+      release = version = __version__
+      switcher_version = get_version_match(version)
+
+4. Modify the ``pyproject.toml`` file to include the following lines, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively:
 
 .. code:: toml
 
@@ -199,11 +220,11 @@ the repository has a ``docs`` directory with a Sphinx documentation setup.
 
         This project uses [towncrier](https://towncrier.readthedocs.io/) and the
         changes for the upcoming release can be found in
-        this [repository file](doc/changelog.d/changelog.rst).
+        this [repository file](doc/source/changelog.rst).
 
 
-A reference pull request for the changes can be found in the `PyAnsys Geometry repository <https://github.com/ansys/pyansys-geometry/pull/1138>`_.
-This pull request includes some other changes, but the changelog implementation is the same as described in this document.
+Reference pull requests for the changes can be found in the `PyAnsys Geometry <https://github.com/ansys/pyansys-geometry/pull/1138>`_ and `PyMechanical <https://github.com/ansys/pymechanical/pull/757/files>_` repositories.
+The PyAnsys-Geometry pull request includes some other changes, but the changelog implementation is the same as described in this document.
 
 ``towncrier`` commands
 ----------------------

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -42,7 +42,7 @@ At the end of the ``.github/workflows/label.yml`` file, add the following lines 
 
 |
 
-Next, follow the instructions in the "Include the release notes in your documentation" or "Include the release notes in ``CHANGELOG.md``" sections depending on your preference.
+Next, follow the instructions to create release notes in your `documentation <#include-the-release-notes-in-your-documentation>`_ or `CHANGELOG.md file <#include-the-release-notes-in-changelog-md>`_ depending on your preference.
 
 Include the release notes in your documentation
 -----------------------------------------------

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -91,7 +91,7 @@ Include the release notes in your documentation
 
 .. note::
 
-    If your project previously used ``CHANGELOG.md`` to record the release notes, change the description under "Release notes", replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively, and ``{latest-version}`` with the most recent version in your ``CHANGELOG.md`` file:
+    If your project previously used ``CHANGELOG.md`` to record the release notes, change the description under "Release notes," replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively, and ``{latest-version}`` with the most recent version in your ``CHANGELOG.md`` file:
 
     .. code:: rst
 

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -5,6 +5,7 @@ dev
 GitHub
 pytest
 PyPI
+toctree
 towncrier
 TXT
 PyAnsys Dashboard


### PR DESCRIPTION
Updated the doc-changelog migration guide to clarify setting up the release notes in the `CHANGELOG.md` file versus the documentation (`changelog.rst`). Although a couple of the steps are repeated in the "release notes in your documentation" and "release notes in `CHANGELOG.md`" sections, I think it's clearer. 

Previously, you would have to set up everything for the `CHANGELOG.md` configuration, and then change most of what you had set up if you want to include it in your documentation instead.