### PR TITLE
feat: update dependabot to new wildcard syntaxt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directories: 
+    directories:
       - "**/*"
     schedule:
       interval: "daily"
@@ -12,7 +12,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directories: 
+    directories:
       - "**/*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directories:
-      - "**/*"
+    directory: "/requirements"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directories: "**/*"
+    directories: "!(requirements)/*"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/requirements"
+    directories: "/requirements/*"
     schedule:
       interval: "daily"
     commit-message:
@@ -11,7 +11,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories: "**/*"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directories: 
-      - "/requirements/*"
+      - "**/*"
     schedule:
       interval: "daily"
     commit-message:
@@ -13,7 +13,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directories: 
-      - "!(requirements)/*"
+      - "**/*"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directories: "/requirements/*"
+    directories: 
+      - "/requirements/*"
     schedule:
       interval: "daily"
     commit-message:
@@ -11,7 +12,8 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directories: "!(requirements)/*"
+    directories: 
+      - "!(requirements)/*"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Solves for #418 by implementing the new dependabot syntax. This version of dependabot is still in beta mode.