### PR TITLE
fix: investigate dependabot syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/requirements"
+    directories:
+      - "/requirements"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
This pull-request is a continuation of #500. Uses the `directories` key in both ecosystems to investigate the issues from https://github.com/ansys/actions/network/updates