### PR TITLE
feat: add an optional input for checkout so it can be skipped, if needed

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: inputs.checkout == 'true'
+      if: inputs.checkout == true
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: inputs.checkout == true
+      if: ${{ inputs.checkout }}
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: inputs.checkout == true
+      if: inputs.checkout == 'true'
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -85,11 +85,21 @@ inputs:
     default: true
     type: boolean
 
+  checkout:
+    description: >
+      Whether to do a checkout step or not. If ``true``, the checkout step is performed.
+      If ``false``, the checkout is skipped allowing the workspace from a prior step to
+      be used unaltered. By default it is set to ``true``.
+    required: false
+    default: true
+    type: boolean
+
 runs:
   using: "composite"
   steps:
 
     - name: "Install Git and clone project"
+      if: checkout
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: ${{ inputs.checkout }}
+      if: {{ inputs.checkout == 'true' }}
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: {{ inputs.checkout == 'true' }}
+      if: ${{ inputs.checkout == 'true' }}
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -99,7 +99,7 @@ runs:
   steps:
 
     - name: "Install Git and clone project"
-      if: checkout
+      if: inputs.checkout == 'true'
       uses: actions/checkout@v4
 
     - name: "Set up Python ${{ inputs.python-version }}"


### PR DESCRIPTION
The checkout remains the default, but can be skipped if set to false. This can be useful when there are prior steps to build elements that should be packed into the wheelhouse. For example, some projects have a step to build cython .pyd files and those .pyd files should go into the wheel file. The checkout step would purge the repo and clear the files from the previous build step. Now, projects that have this requirement can opt to skip the checkout.