### PR TITLE
fix: only compress content inside html folder

### DIFF
--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -369,7 +369,8 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
-        zip -r documentation-html.zip ${{ env.EXPECTED_BUILD_DIR }}\html
+        cd ${{ env.EXPECTED_BUILD_DIR }}\html; zip -r documentation-html.zip *; cd ..\..\..
+        mv ${{ env.EXPECTED_BUILD_DIR }}\html\documentation-html.zip ${{ env.EXPECTED_DOWNLOAD_DIR }}
         mv documentation-html.zip ${{ env.EXPECTED_DOWNLOAD_DIR }}
         if (Test-Path ${{ env.EXPECTED_BUILD_DIR }}\latex\${{ env.PDF_FILENAME }}) {
           cp ${{ env.EXPECTED_BUILD_DIR }}\latex\${{ env.PDF_FILENAME }} ${{ env.EXPECTED_DOWNLOAD_DIR }}


### PR DESCRIPTION
Current Windows implementation was zipping the entire "doc/build..." folder structure. We are only interested in the contents inside the "html" folder