### PR TITLE
feat: allow users to indicate files dir

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -41,6 +41,13 @@ inputs:
 
   # Optional inputs
 
+  files:
+    description: >
+      Path to the directory containing the documentation files.
+    default: 'doc'
+    required: false
+    type: string
+
   vale-config:
     description: >
       Path to the Vale configuration file.
@@ -168,7 +175,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
-        files: doc
+        files: ${{ inputs.files }}
         reporter: github-pr-check
         level: error
         filter_mode: nofilter


### PR DESCRIPTION
After a discussion on #432, we thought about allowing users to specify the location of their documentation files. With these changes, projects with `doc/` and `examples/` folders can now run:

```yml
  doc-style:
    name: "Doc style ${{ matrix.folder }}"
    runs-on: ubuntu-latest
    strategy:
      matrix:
        folder: ["doc", "examples"]
      fail-fast: false
  steps:
    - uses: ansys/actions/doc-style@v6
      with:
        files: ${{ matrix.folder }}
        vale-config: ${{ matrix.folder }}/.vale.ini
        token: ${{ secrets.GITHUB_TOKEN }}
```