### PR TITLE
fix: peaceiris/actions-gh-pages@v4 version

### DIFF
--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -360,7 +360,7 @@ runs:
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
       if: inputs.repository == 'current'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         publish_dir: .
         publish_branch: ${{ inputs.branch }}
@@ -371,7 +371,7 @@ runs:
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
       if: inputs.repository != 'current'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         publish_dir: .
         publish_branch: ${{ inputs.branch }}

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -537,7 +537,7 @@ runs:
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
       if: inputs.repository == 'current'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         publish_dir: .
         publish_branch: ${{ inputs.branch }}
@@ -548,7 +548,7 @@ runs:
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
       if: inputs.repository != 'current'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         publish_dir: .
         publish_branch: ${{ inputs.branch }}


### PR DESCRIPTION
Updates the version of the `peaceiris/actions-gh-pages` to v4. Opening this as a fix so we can cherry-pick it into `release/6.1` and perform a patch.