### PR TITLE
fix: make doc-changelog commit message compliant

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -211,6 +211,6 @@ runs:
         if [ ! -z "$modified" ]; then
           echo "modified: $modified"
           # Commit and push fragment
-          git commit -m "Adding changelog entry: $fragment"
+          git commit -m "chore: adding changelog file $fragment"
           git push
         fi


### PR DESCRIPTION
Changed the commit message to be `chore: adding changelog file $fragment`, where fragment is the name of the file