### PR TITLE
feat: doc-changelog conventional commits

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -140,8 +140,8 @@ runs:
       shell: bash
       run: |
         pr_title="${{ env.PR_TITLE }}"
-        echo "${pr_title%%:*}"
-        echo CC_TYPE='"${pr_title%%:*}"' >> $GITHUB_ENV
+        cc_type="${pr_title%%:*}"
+        echo CC_TYPE=$cc_type >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}
@@ -166,7 +166,7 @@ runs:
         import os
 
         # Get conventional commit type from env variable
-        cc_type = "${{ env.CC_TYPE }}".lower()
+        cc_type = ${{ env.CC_TYPE }}.lower()
 
         print(cc_type)
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -273,7 +273,9 @@ runs:
         use_labels = "${{ inputs.use-labels }}"
 
         # Capitalize first letter of string, so it becomes True or False
-        use_labels = use_labels[0].upper() + use_labels[1:]
+        use_labels = bool(use_labels[0].upper() + use_labels[1:])
+
+        print(use_labels)
 
         # If not using label, remove conventional commit type from title
         if not use_labels:

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -105,7 +105,16 @@ runs:
     #   with:
     #     token: ${{ inputs.token }}
 
+    - name: "Check pull-request title follows conventional commits style"
+      id: lowercase
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+      continue-on-error: true
+
     - name: "Check pull-request title follows conventional commits style with upper case"
+      id: caps
       if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
       uses: amannn/action-semantic-pull-request@v5
       env:
@@ -125,11 +134,9 @@ runs:
           TEST
       continue-on-error: true
 
-    - name: "Check pull-request title follows conventional commits style"
-      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
-      uses: amannn/action-semantic-pull-request@v5
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
+    - name: "Check failures"
+      if: steps.lowercase.outcome == 'failure' && steps.caps.outcome == 'failure'
+      run: exit 1
 
     # - name: "Get labels in the pull request"
     #   if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -137,10 +137,20 @@ runs:
       if: ${{ inputs.use-labels == 'false' }}
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
-      shell: bash
+      shell: python
       run: |
-        cc_type=$(echo ${{ env.PR_TITLE }} | cut -d: -f1)
-        echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
+        import os
+
+        pr_title = f"""{os.environ.get('PR_TITLE')}"""
+        colon_index = pr_title.index(":")
+        cc_type = pr_title[:4]
+        print(cc_type)
+
+        # Get the GITHUB_ENV variable
+        github_env = os.getenv('GITHUB_ENV')
+
+        with open(github_env, "a") as f:
+            f.write(f"CC_TYPE={cc_type}")
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -139,7 +139,7 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: |
-        pr_title=${{ env.PR_TITLE }}
+        pr_title="${{ env.PR_TITLE }}"
         echo "${pr_title%%:*}"
         echo CC_TYPE='"${pr_title%%:*}"' >> $GITHUB_ENV
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -141,7 +141,7 @@ runs:
       run: |
         pr_title="${{ env.PR_TITLE }}"
         cc_type="${pr_title%%:*}"
-        echo CC_TYPE=$cc_type >> $GITHUB_ENV
+        echo CC_TYPE='"$cc_type"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -140,8 +140,7 @@ runs:
       shell: bash
       run: |
         pr_title=${{ env.PR_TITLE }}
-        cc_type="${ ${{ env.PR_TITLE }}%%:* }"
-        # "${pr_title%%:*}"
+        cc_type=$(echo $pr_title | cut -d: -f1)
         echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -280,7 +280,7 @@ runs:
         # If not using label, remove conventional commit type from title
         if not use_labels:
             colon_index = clean_title.index(":")
-            clean_title = clean_title[4:]
+            clean_title = clean_title[colon_index:]
 
         print(clean_title)
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -273,9 +273,11 @@ runs:
         use_labels = "${{ inputs.use-labels }}"
 
         # Capitalize first letter of string, so it becomes True or False
-        use_labels = bool(use_labels[0].upper() + use_labels[1:])
+        use_labels = use_labels[0].upper() + use_labels[1:]
 
         print(use_labels)
+
+        print(bool(use_labels))
 
         # If not using label, remove conventional commit type from title
         if not use_labels:

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -275,12 +275,8 @@ runs:
         # Capitalize first letter of string, so it becomes True or False
         use_labels = use_labels[0].upper() + use_labels[1:]
 
-        print(use_labels)
-
-        print(bool(use_labels))
-
         # If not using label, remove conventional commit type from title
-        if not use_labels:
+        if use_labels == "False":
             colon_index = clean_title.index(":")
             clean_title = clean_title[colon_index:]
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -141,7 +141,7 @@ runs:
       run: |
         pr_title="${{ env.PR_TITLE }}"
         cc_type="${pr_title%%:*}"
-        echo CC_TYPE='"$cc_type"' >> $GITHUB_ENV
+        echo CC_TYPE=$cc_type >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}
@@ -166,7 +166,7 @@ runs:
         import os
 
         # Get conventional commit type from env variable
-        cc_type = ${{ env.CC_TYPE }}.lower()
+        cc_type = "${{ env.CC_TYPE }}".lower()
 
         print(cc_type)
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -139,8 +139,7 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: |
-        pr_title=${{ env.PR_TITLE }}
-        cc_type=$(echo $pr_title | cut -d: -f1)
+        cc_type=$(echo ${{ env.PR_TITLE }} | cut -d: -f1)
         echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -65,6 +65,14 @@ inputs:
     default: true
     type: boolean
 
+  use-labels:
+    description: >
+      Whether to use labels to categorize towncrier fragments or conventional
+      commits.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -91,126 +99,159 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }}
 
-    - name: "Get labels in the pull request"
+    # - name: "Run commit style checks"
+    #   if: ${{ inputs.use-labels == 'false' }}
+    #   uses: ansys/actions/commit-style@v6
+    #   with:
+    #     token: ${{ inputs.token }}
+
+    - name: "Check pull-request title follows conventional commits style"
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
+      uses: amannn/action-semantic-pull-request@v5
       env:
-        OWNER: ${{ github.repository_owner }}
-        REPO_NAME: ${{ github.event.repository.name }}
-        PR_NUMBER: ${{ github.event.number }}
-        GH_TOKEN: ${{ inputs.token }}
-      shell: bash
-      run: |
-        # Get the labels in the pull request
-        pr_labels=$(gh api repos/${{ env.OWNER }}/${{ env.REPO_NAME }}/pulls/${{ env.PR_NUMBER }} --jq '.labels.[].name')
+        GITHUB_TOKEN: ${{ inputs.token }}
 
-        # Save the labels to an environment variable
-        # For example, LABELS="enhancement maintenance"
-        echo LABELS='"'$pr_labels'"' >> $GITHUB_ENV
-
-    - name: "Set PR label environment variable"
-      shell: python
-      run: |
-        import os
-
-        # Create a list of labels found in the pull request
-        # For example, "enhancement maintenance".split() -> ["enhancement", "maintenance"]
-        existing_labels = ${{ env.LABELS }}.split()
-
-        # Dictionary with the key as a label from .github/workflows/label.yml and
-        # value as the corresponding section in the changelog
-        pr_labels = {
-          "enhancement": "added",
-          "bug": "fixed",
-          "dependencies": "dependencies",
-          "maintenance": "changed"
-        }
-
-        def get_changelog_section(pr_labels, existing_labels):
-          """Find the changelog section corresponding to the label in the PR."""
-          label_type = ""
-
-          for key, value in pr_labels.items():
-              if key in existing_labels:
-                  label_type = value
-                  return label_type
-
-          # If no labels are in the PR, it goes into the miscellaneous category
-          label_type = "miscellaneous"
-          return label_type
-
-        # Get the GITHUB_ENV variable
-        github_env = os.getenv('GITHUB_ENV')
-
-        # Append the PR_LABEL with its value to GITHUB_ENV
-        # For example, PR_LABEL="added" if the PR had an "enhancement" label
-        with open(github_env, "a") as f:
-            f.write(f"PR_LABEL={get_changelog_section(pr_labels, existing_labels)}")
-
-    - name: "Remove PR fragment file if it already exists"
+    - name: "Check pull-request title follows conventional commits style with upper case"
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && failure() }}
+      uses: amannn/action-semantic-pull-request@v5
       env:
-        PR_NUMBER: ${{ github.event.number }}
-      shell: bash
-      run: |
-        # Find files containing the PR number
-        # For example, 20.*.md
-        file=`find . -type f -name "${{ env.PR_NUMBER }}.*.md"`
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        types: |
+          BUILD
+          CHORE
+          CI
+          DOCS
+          FEAT
+          FIX
+          PERF
+          REFACTOR
+          REVERT
+          STYLE
+          TEST
 
-        # If the fragment file exists, then delete the file
-        if [ ! -z "$file" ]; then
-          echo "Removing $file"
-          rm $file
-        fi
+    # - name: "Get labels in the pull request"
+    #   if: ${{ inputs.use-labels == 'true' }}
+    #   env:
+    #     OWNER: ${{ github.repository_owner }}
+    #     REPO_NAME: ${{ github.event.repository.name }}
+    #     PR_NUMBER: ${{ github.event.number }}
+    #     GH_TOKEN: ${{ inputs.token }}
+    #   shell: bash
+    #   run: |
+    #     # Get the labels in the pull request
+    #     pr_labels=$(gh api repos/${{ env.OWNER }}/${{ env.REPO_NAME }}/pulls/${{ env.PR_NUMBER }} --jq '.labels.[].name')
 
-    - name: "Clean PR title"
-      env:
-        PR_TITLE: ${{ github.event.pull_request.title }}
-      shell: python
-      run: |
-        import os
+    #     # Save the labels to an environment variable
+    #     # For example, LABELS="enhancement maintenance"
+    #     echo LABELS='"'$pr_labels'"' >> $GITHUB_ENV
 
-        # Retrieve title
-        clean_title = os.getenv('PR_TITLE')
+    # - name: "Set PR label environment variable"
+    #   if: ${{ inputs.use-labels == 'true' }}
+    #   shell: python
+    #   run: |
+    #     import os
 
-        # Remove extra whitespace
-        clean_title = clean_title.strip()
+    #     # Create a list of labels found in the pull request
+    #     # For example, "enhancement maintenance".split() -> ["enhancement", "maintenance"]
+    #     existing_labels = ${{ env.LABELS }}.split()
 
-        # Add backslash in front of backtick and double quote
-        clean_title = clean_title.replace("`", "\`").replace('"', '\\"')
+    #     # Dictionary with the key as a label from .github/workflows/label.yml and
+    #     # value as the corresponding section in the changelog
+    #     pr_labels = {
+    #       "enhancement": "added",
+    #       "bug": "fixed",
+    #       "dependencies": "dependencies",
+    #       "maintenance": "changed"
+    #     }
 
-        # Get the GITHUB_ENV variable
-        github_env = os.getenv('GITHUB_ENV')
+    #     def get_changelog_section(pr_labels, existing_labels):
+    #       """Find the changelog section corresponding to the label in the PR."""
+    #       label_type = ""
 
-        # Append the CLEAN_TITLE with its value to GITHUB_ENV
-        with open(github_env, "a") as f:
-            f.write(f"CLEAN_TITLE={clean_title}")
+    #       for key, value in pr_labels.items():
+    #           if key in existing_labels:
+    #               label_type = value
+    #               return label_type
 
-    - name: "Create and commit towncrier fragment"
-      env:
-        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        PR_NUMBER: ${{ github.event.number }}
-      shell: bash
-      run: |
-        # Changelog fragment file in the following format
-        # For example, 20.added.md
-        fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
+    #       # If no labels are in the PR, it goes into the miscellaneous category
+    #       label_type = "miscellaneous"
+    #       return label_type
 
-        # Create changelog fragment with towncrier
-        # Fragment file contains the title of the PR
-        towncrier create -c "${{ env.CLEAN_TITLE }}" $fragment
+    #     # Get the GITHUB_ENV variable
+    #     github_env = os.getenv('GITHUB_ENV')
 
-        # Configure git username & email
-        git config user.name 'pyansys-ci-bot'
-        git config user.email '92810346+pyansys-ci-bot@users.noreply.github.com'
+    #     # Append the PR_LABEL with its value to GITHUB_ENV
+    #     # For example, PR_LABEL="added" if the PR had an "enhancement" label
+    #     with open(github_env, "a") as f:
+    #         f.write(f"PR_LABEL={get_changelog_section(pr_labels, existing_labels)}")
 
-        # Add towncrier fragment
-        git add .
+    # - name: "Remove PR fragment file if it already exists"
+    #   env:
+    #     PR_NUMBER: ${{ github.event.number }}
+    #   shell: bash
+    #   run: |
+    #     # Find files containing the PR number
+    #     # For example, 20.*.md
+    #     file=`find . -type f -name "${{ env.PR_NUMBER }}.*.md"`
 
-        # Check if file was modified
-        modified=`git diff HEAD --name-only`
+    #     # If the fragment file exists, then delete the file
+    #     if [ ! -z "$file" ]; then
+    #       echo "Removing $file"
+    #       rm $file
+    #     fi
 
-        # If the file was modified, commit & push it to the branch
-        if [ ! -z "$modified" ]; then
-          echo "modified: $modified"
-          # Commit and push fragment
-          git commit -m "chore: adding changelog file $fragment"
-          git push
-        fi
+    # - name: "Clean PR title"
+    #   env:
+    #     PR_TITLE: ${{ github.event.pull_request.title }}
+    #   shell: python
+    #   run: |
+    #     import os
+
+    #     # Retrieve title
+    #     clean_title = os.getenv('PR_TITLE')
+
+    #     # Remove extra whitespace
+    #     clean_title = clean_title.strip()
+
+    #     # Add backslash in front of backtick and double quote
+    #     clean_title = clean_title.replace("`", "\`").replace('"', '\\"')
+
+    #     # Get the GITHUB_ENV variable
+    #     github_env = os.getenv('GITHUB_ENV')
+
+    #     # Append the CLEAN_TITLE with its value to GITHUB_ENV
+    #     with open(github_env, "a") as f:
+    #         f.write(f"CLEAN_TITLE={clean_title}")
+
+    # - name: "Create and commit towncrier fragment"
+    #   env:
+    #     PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+    #     PR_NUMBER: ${{ github.event.number }}
+    #   shell: bash
+    #   run: |
+    #     # Changelog fragment file in the following format
+    #     # For example, 20.added.md
+    #     fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
+
+    #     # Create changelog fragment with towncrier
+    #     # Fragment file contains the title of the PR
+    #     towncrier create -c "${{ env.CLEAN_TITLE }}" $fragment
+
+    #     # Configure git username & email
+    #     git config user.name 'pyansys-ci-bot'
+    #     git config user.email '92810346+pyansys-ci-bot@users.noreply.github.com'
+
+    #     # Add towncrier fragment
+    #     git add .
+
+    #     # Check if file was modified
+    #     modified=`git diff HEAD --name-only`
+
+    #     # If the file was modified, commit & push it to the branch
+    #     if [ ! -z "$modified" ]; then
+    #       echo "modified: $modified"
+    #       # Commit and push fragment
+    #       git commit -m "chore: adding changelog file $fragment"
+    #       git push
+    #     fi

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -126,7 +126,7 @@ runs:
       continue-on-error: true
 
     - name: "Check pull-request title follows conventional commits style"
-      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && failure() }}
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
       uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -99,12 +99,6 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }}
 
-    # - name: "Run commit style checks"
-    #   if: ${{ inputs.use-labels == 'false' }}
-    #   uses: ansys/actions/commit-style@v6
-    #   with:
-    #     token: ${{ inputs.token }}
-
     - name: "Check pull-request title follows conventional commits style"
       id: lowercase
       if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
@@ -139,134 +133,180 @@ runs:
       shell: bash
       run: exit 1
 
-    - name: "Print good statement"
-      if: ${{ inputs.use-labels == 'true' }}
+    - name: "Get conventional commit type from title"
+      if: ${{ inputs.use-labels == 'false' }}
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
-      run: echo "good!"
+      run: |
+        pr_title=${{ env.PR_TITLE }}
+        echo "${pr_title%%:*}"
+        echo CC_TYPE='"${pr_title%%:*}"' >> $GITHUB_ENV
 
+    - name: "Get labels in the pull request"
+      if: ${{ inputs.use-labels == 'true' }}
+      env:
+        OWNER: ${{ github.repository_owner }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        PR_NUMBER: ${{ github.event.number }}
+        GH_TOKEN: ${{ inputs.token }}
+      shell: bash
+      run: |
+        # Get the labels in the pull request
+        pr_labels=$(gh api repos/${{ env.OWNER }}/${{ env.REPO_NAME }}/pulls/${{ env.PR_NUMBER }} --jq '.labels.[].name')
 
-    # - name: "Get labels in the pull request"
-    #   if: ${{ inputs.use-labels == 'true' }}
-    #   env:
-    #     OWNER: ${{ github.repository_owner }}
-    #     REPO_NAME: ${{ github.event.repository.name }}
-    #     PR_NUMBER: ${{ github.event.number }}
-    #     GH_TOKEN: ${{ inputs.token }}
-    #   shell: bash
-    #   run: |
-    #     # Get the labels in the pull request
-    #     pr_labels=$(gh api repos/${{ env.OWNER }}/${{ env.REPO_NAME }}/pulls/${{ env.PR_NUMBER }} --jq '.labels.[].name')
+        # Save the labels to an environment variable
+        # For example, LABELS="enhancement maintenance"
+        echo LABELS='"'$pr_labels'"' >> $GITHUB_ENV
 
-    #     # Save the labels to an environment variable
-    #     # For example, LABELS="enhancement maintenance"
-    #     echo LABELS='"'$pr_labels'"' >> $GITHUB_ENV
+    - name: "Set CHANGELOG category based on conventional commit type"
+      if: ${{ inputs.use-labels == 'false' }}
+      shell: python
+      run: |
+        import os
 
-    # - name: "Set PR label environment variable"
-    #   if: ${{ inputs.use-labels == 'true' }}
-    #   shell: python
-    #   run: |
-    #     import os
+        # Get conventional commit type from env variable
+        cc_type = ${{ env.CC_TYPE }}
 
-    #     # Create a list of labels found in the pull request
-    #     # For example, "enhancement maintenance".split() -> ["enhancement", "maintenance"]
-    #     existing_labels = ${{ env.LABELS }}.split()
+        cc_type_changelog_dict = {
+          "feat": "added",
+          "fix": "fixed",
+          "revert": "changed",
+          "style": "changed",
+          "refactor": "changed",
+          "test": "tests",
+          "chore": "changed",
+          "perf": "changed",
+          "ci": "changed",
+          "docs": "documentation"
+          "build": "dependencies"
+        }
 
-    #     # Dictionary with the key as a label from .github/workflows/label.yml and
-    #     # value as the corresponding section in the changelog
-    #     pr_labels = {
-    #       "enhancement": "added",
-    #       "bug": "fixed",
-    #       "dependencies": "dependencies",
-    #       "maintenance": "changed"
-    #     }
+        changelog_section = cc_type_changelog_dict[cc_type]
 
-    #     def get_changelog_section(pr_labels, existing_labels):
-    #       """Find the changelog section corresponding to the label in the PR."""
-    #       label_type = ""
+        # Get the GITHUB_ENV variable
+        github_env = os.getenv('GITHUB_ENV')
 
-    #       for key, value in pr_labels.items():
-    #           if key in existing_labels:
-    #               label_type = value
-    #               return label_type
+        # Append the CHANGELOG_SECTION with its value to GITHUB_ENV
+        # For example, CHANGELOG_SECTION="added" if the conventional commit title was "feat"
+        with open(github_env, "a") as f:
+            f.write(f"CHANGELOG_SECTION={changelog_section}")
 
-    #       # If no labels are in the PR, it goes into the miscellaneous category
-    #       label_type = "miscellaneous"
-    #       return label_type
+    - name: "Set PR label environment variable"
+      if: ${{ inputs.use-labels == 'true' }}
+      shell: python
+      run: |
+        import os
 
-    #     # Get the GITHUB_ENV variable
-    #     github_env = os.getenv('GITHUB_ENV')
+        # Create a list of labels found in the pull request
+        # For example, "enhancement maintenance".split() -> ["enhancement", "maintenance"]
+        existing_labels = ${{ env.LABELS }}.split()
 
-    #     # Append the PR_LABEL with its value to GITHUB_ENV
-    #     # For example, PR_LABEL="added" if the PR had an "enhancement" label
-    #     with open(github_env, "a") as f:
-    #         f.write(f"PR_LABEL={get_changelog_section(pr_labels, existing_labels)}")
+        # Dictionary with the key as a label from .github/workflows/label.yml and
+        # value as the corresponding section in the changelog
+        pr_labels = {
+          "enhancement": "added",
+          "bug": "fixed",
+          "documentation": "documentation",
+          "tests": "tests",
+          "dependencies": "dependencies",
+          "maintenance": "changed"
+        }
 
-    # - name: "Remove PR fragment file if it already exists"
-    #   env:
-    #     PR_NUMBER: ${{ github.event.number }}
-    #   shell: bash
-    #   run: |
-    #     # Find files containing the PR number
-    #     # For example, 20.*.md
-    #     file=`find . -type f -name "${{ env.PR_NUMBER }}.*.md"`
+        def get_changelog_section(pr_labels, existing_labels):
+          """Find the changelog section corresponding to the label in the PR."""
+          label_type = ""
 
-    #     # If the fragment file exists, then delete the file
-    #     if [ ! -z "$file" ]; then
-    #       echo "Removing $file"
-    #       rm $file
-    #     fi
+          for key, value in pr_labels.items():
+              if key in existing_labels:
+                  label_type = value
+                  return label_type
 
-    # - name: "Clean PR title"
-    #   env:
-    #     PR_TITLE: ${{ github.event.pull_request.title }}
-    #   shell: python
-    #   run: |
-    #     import os
+          # If no labels are in the PR, it goes into the miscellaneous category
+          label_type = "miscellaneous"
+          return label_type
 
-    #     # Retrieve title
-    #     clean_title = os.getenv('PR_TITLE')
+        # Get the GITHUB_ENV variable
+        github_env = os.getenv('GITHUB_ENV')
 
-    #     # Remove extra whitespace
-    #     clean_title = clean_title.strip()
+        # Append the CHANGELOG_SECTION with its value to GITHUB_ENV
+        # For example, CHANGELOG_SECTION="added" if the PR had an "enhancement" label
+        with open(github_env, "a") as f:
+            f.write(f"CHANGELOG_SECTION={get_changelog_section(pr_labels, existing_labels)}")
 
-    #     # Add backslash in front of backtick and double quote
-    #     clean_title = clean_title.replace("`", "\`").replace('"', '\\"')
+    - name: "Remove PR fragment file if it already exists"
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      shell: bash
+      run: |
+        # Find files containing the PR number
+        # For example, 20.*.md
+        file=`find . -type f -name "${{ env.PR_NUMBER }}.*.md"`
 
-    #     # Get the GITHUB_ENV variable
-    #     github_env = os.getenv('GITHUB_ENV')
+        # If the fragment file exists, then delete the file
+        if [ ! -z "$file" ]; then
+          echo "Removing $file"
+          rm $file
+        fi
 
-    #     # Append the CLEAN_TITLE with its value to GITHUB_ENV
-    #     with open(github_env, "a") as f:
-    #         f.write(f"CLEAN_TITLE={clean_title}")
+    - name: "Clean PR title"
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      shell: python
+      run: |
+        import os
 
-    # - name: "Create and commit towncrier fragment"
-    #   env:
-    #     PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-    #     PR_NUMBER: ${{ github.event.number }}
-    #   shell: bash
-    #   run: |
-    #     # Changelog fragment file in the following format
-    #     # For example, 20.added.md
-    #     fragment="${{ env.PR_NUMBER }}.${{ env.PR_LABEL }}.md"
+        # Retrieve title
+        clean_title = os.getenv('PR_TITLE')
 
-    #     # Create changelog fragment with towncrier
-    #     # Fragment file contains the title of the PR
-    #     towncrier create -c "${{ env.CLEAN_TITLE }}" $fragment
+        # If not using label, remove conventional commit type from title
+        if not ${{ inputs.use-labels }}:
+            colon_index = clean_title.index(":")
+            clean_title = clean_title[4:]
 
-    #     # Configure git username & email
-    #     git config user.name 'pyansys-ci-bot'
-    #     git config user.email '92810346+pyansys-ci-bot@users.noreply.github.com'
+        print(clean_title)
 
-    #     # Add towncrier fragment
-    #     git add .
+        # Remove extra whitespace
+        clean_title = clean_title.strip()
 
-    #     # Check if file was modified
-    #     modified=`git diff HEAD --name-only`
+        # Add backslash in front of backtick and double quote
+        clean_title = clean_title.replace("`", "\`").replace('"', '\\"')
 
-    #     # If the file was modified, commit & push it to the branch
-    #     if [ ! -z "$modified" ]; then
-    #       echo "modified: $modified"
-    #       # Commit and push fragment
-    #       git commit -m "chore: adding changelog file $fragment"
-    #       git push
-    #     fi
+        # Get the GITHUB_ENV variable
+        github_env = os.getenv('GITHUB_ENV')
+
+        # Append the CLEAN_TITLE with its value to GITHUB_ENV
+        with open(github_env, "a") as f:
+            f.write(f"CLEAN_TITLE={clean_title}")
+
+    - name: "Create and commit towncrier fragment"
+      env:
+        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        PR_NUMBER: ${{ github.event.number }}
+      shell: bash
+      run: |
+        # Changelog fragment file in the following format
+        # For example, 20.added.md
+        fragment="${{ env.PR_NUMBER }}.${{ env.CHANGELOG_SECTION }}.md"
+
+        # Create changelog fragment with towncrier
+        # Fragment file contains the title of the PR
+        towncrier create -c "${{ env.CLEAN_TITLE }}" $fragment
+
+        # Configure git username & email
+        git config user.name 'pyansys-ci-bot'
+        git config user.email '92810346+pyansys-ci-bot@users.noreply.github.com'
+
+        # Add towncrier fragment
+        git add .
+
+        # Check if file was modified
+        modified=`git diff HEAD --name-only`
+
+        # If the file was modified, commit & push it to the branch
+        if [ ! -z "$modified" ]; then
+          echo "modified: $modified"
+          # Commit and push fragment
+          git commit -m "chore: adding changelog file $fragment"
+          git push
+        fi

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -166,7 +166,9 @@ runs:
         import os
 
         # Get conventional commit type from env variable
-        cc_type = ${{ env.CC_TYPE }}
+        cc_type = "${{ env.CC_TYPE }}".lower()
+
+        print(cc_type)
 
         cc_type_changelog_dict = {
           "feat": "added",
@@ -178,8 +180,8 @@ runs:
           "chore": "changed",
           "perf": "changed",
           "ci": "changed",
-          "docs": "documentation"
-          "build": "dependencies"
+          "docs": "documentation",
+          "build": "dependencies",
         }
 
         changelog_section = cc_type_changelog_dict[cc_type]

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -105,14 +105,8 @@ runs:
     #   with:
     #     token: ${{ inputs.token }}
 
-    - name: "Check pull-request title follows conventional commits style"
-      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
-      uses: amannn/action-semantic-pull-request@v5
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-
     - name: "Check pull-request title follows conventional commits style with upper case"
-      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && failure() }}
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) }}
       uses: amannn/action-semantic-pull-request@v5
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
@@ -129,6 +123,13 @@ runs:
           REVERT
           STYLE
           TEST
+      continue-on-error: true
+
+    - name: "Check pull-request title follows conventional commits style"
+      if: ${{ inputs.use-labels == 'false' && ((github.event_name == 'pull_request_target') || (github.event_name == 'pull_request')) && failure() }}
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     # - name: "Get labels in the pull request"
     #   if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -278,7 +278,7 @@ runs:
         # If not using label, remove conventional commit type from title
         if use_labels == "False":
             colon_index = clean_title.index(":")
-            clean_title = clean_title[colon_index:]
+            clean_title = clean_title[colon_index+1:]
 
         print(clean_title)
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -136,7 +136,14 @@ runs:
 
     - name: "Check failures"
       if: steps.lowercase.outcome == 'failure' && steps.caps.outcome == 'failure'
+      shell: bash
       run: exit 1
+
+    - name: "Print good statement"
+      if: ${{ inputs.use-labels == 'true' }}
+      shell: bash
+      run: echo "good!"
+
 
     # - name: "Get labels in the pull request"
     #   if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -181,15 +181,15 @@ runs:
         cc_type_changelog_dict = {
           "feat": "added",
           "fix": "fixed",
-          "revert": "changed",
-          "style": "changed",
-          "refactor": "changed",
-          "test": "tests",
-          "chore": "changed",
-          "perf": "changed",
-          "ci": "changed",
           "docs": "documentation",
           "build": "dependencies",
+          "revert": "miscellaneous",
+          "style": "miscellaneous",
+          "refactor": "miscellaneous",
+          "perf": "miscellaneous",
+          "test": "test",
+          "chore": "maintenance",
+          "ci": "maintenance",
         }
 
         changelog_section = cc_type_changelog_dict[cc_type]
@@ -218,9 +218,10 @@ runs:
           "enhancement": "added",
           "bug": "fixed",
           "documentation": "documentation",
-          "tests": "tests",
+          "testing": "test",
           "dependencies": "dependencies",
-          "maintenance": "changed"
+          "CI/CD": "maintenance",
+          "maintenance": "maintenance"
         }
 
         def get_changelog_section(pr_labels, existing_labels):

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -143,14 +143,13 @@ runs:
 
         pr_title = f"""{os.environ.get('PR_TITLE')}"""
         colon_index = pr_title.index(":")
-        cc_type = pr_title[:colon_index]
-        print(cc_type)
+        cc_type = '"'+pr_title[:colon_index]+'"'
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')
 
         with open(github_env, "a") as f:
-            f.write(f"CC_TYPE={cc_type}")
+            f.write(f'CC_TYPE={cc_type}')
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -139,8 +139,9 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: |
-        # pr_title=${{ env.PR_TITLE }}
-        cc_type="${{env.PR_TITLE%%:*}}"
+        pr_title=${{ env.PR_TITLE }}
+        cc_type="${ ${{ env.PR_TITLE }}%%:* }"
+        # "${pr_title%%:*}"
         echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -143,7 +143,7 @@ runs:
 
         pr_title = f"""{os.environ.get('PR_TITLE')}"""
         colon_index = pr_title.index(":")
-        cc_type = pr_title[:4]
+        cc_type = pr_title[:colon_index]
         print(cc_type)
 
         # Get the GITHUB_ENV variable

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -141,7 +141,7 @@ runs:
       run: |
         pr_title="${{ env.PR_TITLE }}"
         cc_type="${pr_title%%:*}"
-        echo CC_TYPE=$cc_type >> $GITHUB_ENV
+        echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"
       if: ${{ inputs.use-labels == 'true' }}
@@ -166,7 +166,7 @@ runs:
         import os
 
         # Get conventional commit type from env variable
-        cc_type = "${{ env.CC_TYPE }}".lower()
+        cc_type = ${{ env.CC_TYPE }}.lower()
 
         print(cc_type)
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -261,8 +261,14 @@ runs:
         # Retrieve title
         clean_title = os.getenv('PR_TITLE')
 
+        # Retrieve use-labels boolean
+        use_labels = "${{ inputs.use-labels }}"
+
+        # Capitalize first letter of string, so it becomes True or False
+        use_labels = use_labels[0].upper() + use_labels[1:]
+
         # If not using label, remove conventional commit type from title
-        if not ${{ inputs.use-labels }}:
+        if not use_labels:
             colon_index = clean_title.index(":")
             clean_title = clean_title[4:]
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -139,8 +139,8 @@ runs:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: bash
       run: |
-        pr_title="${{ env.PR_TITLE }}"
-        cc_type="${pr_title%%:*}"
+        # pr_title=${{ env.PR_TITLE }}
+        cc_type="${env.PR_TITLE%%:*}"
         echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -140,7 +140,7 @@ runs:
       shell: bash
       run: |
         # pr_title=${{ env.PR_TITLE }}
-        cc_type="${env.PR_TITLE%%:*}"
+        cc_type="${{env.PR_TITLE%%:*}}"
         echo CC_TYPE='"'$cc_type'"' >> $GITHUB_ENV
 
     - name: "Get labels in the pull request"

--- a/doc/source/doc-actions/examples/doc-changelog-basic.yml
+++ b/doc/source/doc-actions/examples/doc-changelog-basic.yml
@@ -20,3 +20,4 @@ changelog-fragment:
     - uses: ansys/actions/doc-changelog@{{ version }}
       with:
         token: ${{ '{{ secrets.PYANSYS_CI_BOT_TOKEN }}' }}
+        # use-labels: true  # uncomment this line to use labels instead of conventional commits

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -247,8 +247,13 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
     showcontent = true
 
     [[tool.towncrier.type]]
-    directory = "changed"
-    name = "Changed"
+    directory = "dependencies"
+    name = "Dependencies"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "documentation"
+    name = "Documentation"
     showcontent = true
 
     [[tool.towncrier.type]]
@@ -257,13 +262,18 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
     showcontent = true
 
     [[tool.towncrier.type]]
-    directory = "dependencies"
-    name = "Dependencies"
+    directory = "maintenance"
+    name = "Maintenance"
     showcontent = true
 
     [[tool.towncrier.type]]
     directory = "miscellaneous"
     name = "Miscellaneous"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "test"
+    name = "Test"
     showcontent = true
 
 A reference pull request for these changes can be found in the `PyAnsys Geometry #1023 <https://github.com/ansys/pyansys-geometry/pull/1023/files>`_ pull request.


### PR DESCRIPTION
By default, the doc-changelog action will check if there is a conventional commit type in the PR title (both lowercase and uppercase types are allowed). If you want to use labels to create the changelog fragment, you have to add the `use-labels: true` line to the doc-changelog job.

This will break repositories until the pyproject.toml files are updated to include the additional sections listed in the doc-changelog documentation

Conventional commit tests:

[Fails when there is no conventional commit type in the title](https://github.com/ansys-internal/actions-sandbox/actions/runs/9840920384/job/27166328031?pr=56)
[Passes when there is an all caps conventional commit type in the title](https://github.com/ansys-internal/actions-sandbox/actions/runs/9841008696/job/27166646415?pr=57#step:2:377)
[Passes when there is an all lowercase conventional commit type in the title](https://github.com/ansys-internal/actions-sandbox/actions/runs/9841021730/job/27166695270?pr=58#step:2:377)

Labels tests:

[Documentation label](https://github.com/ansys-internal/actions-sandbox/actions/runs/9841269350/job/27167526398#step:2:333)
[Test label](https://github.com/ansys-internal/actions-sandbox/actions/runs/9841547875/job/27168436603#step:2:333)
