### PR TITLE
refactor: remove non needed inputs

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -42,20 +42,6 @@ inputs:
 
   # Required inputs
 
-  python-version:
-    description: >
-        Python version used for installing and running ``Sphinx``.
-    required: true
-    type: string
-
-  use-python-cache:
-    description: >
-      Whether to use the Python cache for installing previously downloaded
-      libraries. If ``true``, previously downloaded libraries are installed from the
-      Python cache. If ``false``, libraries are downloaded from the PyPI index.
-    required: true
-    type: boolean
-
   sphinxopts:
     description: |
       Set of options to pass to the ``Sphinx`` builder.
@@ -103,12 +89,6 @@ inputs:
       file in the root of the project.
     required: true
     type: string
-
-  checkout:
-    description: >
-      Whether to clone the repository in the CI/CD machine.
-    required: true
-    type: boolean
 
   skip-json-build:
     description: >

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -42,20 +42,6 @@ inputs:
 
   # Required inputs
 
-  python-version:
-    description: >
-        Python version used for installing and running ``Sphinx``.
-    required: true
-    type: string
-
-  use-python-cache:
-    description: >
-      Whether to use the Python cache for installing previously downloaded
-      libraries. If ``true``, previously downloaded libraries are installed from the
-      Python cache. If ``false``, libraries are downloaded from the PyPI index.
-    required: true
-    type: boolean
-
   sphinxopts:
     description: >
       Set of options to pass to the ``Sphinx`` builder.
@@ -95,12 +81,6 @@ inputs:
       file in the root of the project.
     required: true
     type: string
-
-  checkout:
-    description: >
-      Whether to clone the repository in the CI/CD machine.
-    required: true
-    type: boolean
 
   skip-json-build:
     description: >

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -190,15 +190,12 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       uses: ansys/actions/_doc-build-linux@main
       with:
-        python-version: ${{ inputs.python-version }}
-        use-python-cache: ${{ inputs.use-python-cache }}
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
         skip-dependencies-cache: ${{ inputs.skip-dependencies-cache }}
         requires-xvfb: ${{ inputs.requires-xvfb }}
         skip-install: ${{ inputs.skip-install }}
         requirements-file: ${{ inputs.requirements-file }}
-        checkout: ${{ inputs.checkout }}
         skip-json-build: ${{ inputs.skip-json-build }}
         check-links: ${{ inputs.check-links }}
         add-pdf-html-docs-as-assets: ${{ inputs.add-pdf-html-docs-as-assets }}
@@ -217,14 +214,11 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       uses: ansys/actions/_doc-build-windows@main
       with:
-        python-version: ${{ inputs.python-version }}
-        use-python-cache: ${{ inputs.use-python-cache }}
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
         skip-dependencies-cache: ${{ inputs.skip-dependencies-cache }}
         skip-install: ${{ inputs.skip-install }}
         requirements-file: ${{ inputs.requirements-file }}
-        checkout: ${{ inputs.checkout }}
         skip-json-build: ${{ inputs.skip-json-build }}
         check-links: ${{ inputs.check-links }}
         add-pdf-html-docs-as-assets: ${{ inputs.add-pdf-html-docs-as-assets }}


### PR DESCRIPTION
Duplicate of #517 to use a branch name passing CI.

---

Thanks @dipinknair for noticing that some inputs in the private actions were not needed.

This comes from the fact that two steps are performed before running any private action (checkout and setup-python) Since both private actions (windows and linux) are not involved in python setup and git install + clone, this PR removes the following inputs from the private actions:
- python-version
- use-python-cache
- checkout