### PR TITLE
feat: doc-deploy-changelog update main branch option

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -253,7 +253,7 @@ runs:
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
           # Push CHANGELOG.md changes
-          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.update-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
+          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.update-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
             git push
           else
             git push -u origin ${{ env.UPDATE_BRANCH }}

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -83,6 +83,15 @@ inputs:
     default: true
     type: boolean
 
+  use-main-branch:
+    description: >
+      Whether or not to update the CHANGELOG & do the release in the main branch.
+      If ``true``, the branch used to update the CHANGELOG is main.
+      If ``false``, check the value of the update-release-branch input.
+    required: false
+    default: false
+    type: boolean
+
   use-upper-case:
     description: >
       Use of uppercase letters in the "type" field of:
@@ -147,10 +156,21 @@ runs:
         with open(github_env, "a") as f:
             f.write(f"TOWNCRIER_DIR={directory}")
 
+    - name: "Get main branch name"
+      shell: bash
+      run: |
+        head_branch=$(git remote show origin | grep "HEAD branch:")
+        formatted_head_branch=${head_branch#*: }
+
+        echo "MAIN_BRANCH=$formatted_head_branch" >> $GITHUB_ENV
+
     - name: "Set CHANGELOG update branch"
       shell: bash
       run: |
-        if [[ ${{ inputs.update-release-branch }} == "true" ]]; then
+        if [[ ${{ inputs.use-main-branch }} == "true" ]]; then
+          echo "UPDATE_BRANCH=${{ env.MAIN_BRANCH }}" >> $GITHUB_ENV
+          echo "RELEASE_BRANCH_EXISTS=true" >> $GITHUB_ENV
+        elif [[ ${{ inputs.update-release-branch }} == "true" ]]; then
           # Assume release branch is "release/major.minor"
           # v0.1.0 (tag) -> release/0.1
           tag_version=${{ env.TAG_VERSION }}
@@ -168,7 +188,6 @@ runs:
             echo "UPDATE_BRANCH=$release_branch" >> $GITHUB_ENV
             echo "RELEASE_BRANCH_EXISTS=true" >> $GITHUB_ENV
           fi
-
         else
           # maint/changelog-update-v0.1.0
           echo "UPDATE_BRANCH=maint/changelog-update-v${{ env.TAG_VERSION }}" >> $GITHUB_ENV
@@ -183,7 +202,7 @@ runs:
 
         if [ $count -gt 0 ]; then
           # Checkout branch from tag
-          if [[ ${{ inputs.update-release-branch }} == "true" ]] && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
+          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.use-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
             echo "Using release branch"
             git checkout ${{ env.UPDATE_BRANCH }}
             git pull
@@ -225,7 +244,7 @@ runs:
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
           # Push CHANGELOG.md changes
-          if [[ ${{ inputs.update-release-branch }} == "true" ]] && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
+          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.use-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
             git push
           else
             git push -u origin ${{ env.UPDATE_BRANCH }}
@@ -238,17 +257,13 @@ runs:
         fi
 
     - name: "Create PR into main with CHANGELOG changes"
-      if: contains(env.UPDATED_CHANGELOG, 'True')
+      if: ${{ inputs.use-main-branch != 'true' }} && contains(env.UPDATED_CHANGELOG, 'True')
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash
       run: |
-        # Get main branch name
-        head_branch=$(git remote show origin | grep "HEAD branch:")
-        formatted_head_branch=${head_branch#*: }
-
         # Checkout main & create a branch
-        git checkout $formatted_head_branch
+        git checkout ${{ env.MAIN_BRANCH }}
         git pull
 
         # Set branch for PR

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -130,7 +130,7 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.update-release-branch }}" == "true" ] && [ "${{ inputs.update-main-branch }}" == "true" ]; then
-          echo "update-release-branch and update-main-branch cannot both be true."
+          echo "Inputs update-release-branch and update-main-branch cannot both be true."
           echo "To update the main branch, set update-release-branch to false and update-main-branch to true."
           exit 1
         fi

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -257,7 +257,7 @@ runs:
         fi
 
     - name: "Create PR into main with CHANGELOG changes"
-      if: ${{ inputs.use-main-branch != 'true' }} && contains(env.UPDATED_CHANGELOG, 'True')
+      if: ${{ (inputs.use-main-branch != 'true' ) && (env.UPDATED_CHANGELOG == 'True') }}
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -259,14 +259,14 @@ runs:
             git push -u origin ${{ env.UPDATE_BRANCH }}
           fi
 
-          echo "UPDATED_CHANGELOG=True" >> $GITHUB_ENV
+          echo "UPDATED_CHANGELOG=true" >> $GITHUB_ENV
         else
           echo "There are no changelog fragment files to update the CHANGELOG for v${{ env.TAG_VERSION }}"
-          echo "UPDATED_CHANGELOG=False" >> $GITHUB_ENV
+          echo "UPDATED_CHANGELOG=false" >> $GITHUB_ENV
         fi
 
     - name: "Create PR into main with CHANGELOG changes"
-      if: ${{ (inputs.update-main-branch != 'true' ) && (env.UPDATED_CHANGELOG == 'True') }}
+      if: ${{ (inputs.update-main-branch != 'true' ) && (env.UPDATED_CHANGELOG == 'true') }}
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash
@@ -322,7 +322,7 @@ runs:
     - name: "Delete & Re-create tag"
       env:
         GH_TOKEN: ${{ inputs.token }}
-      if: contains(env.UPDATED_CHANGELOG, 'True')
+      if: contains(env.UPDATED_CHANGELOG, 'true')
       shell: bash
       run: |
           # Checkout branch created from tag with CHANGELOG update & pull

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -341,7 +341,7 @@ runs:
           # Create the tag on remote
           git push origin v${{ env.TAG_VERSION }}
 
-          if [[ ${{ inputs.update-release-branch }} == "false" ]] || [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "false" ]]; then
+          if [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "false" ]]; then
             # Delete branch created from deleted tag with CHANGELOG update
             git push origin --delete ${{ env.UPDATE_BRANCH }}
           fi

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -83,9 +83,9 @@ inputs:
     default: true
     type: boolean
 
-  use-main-branch:
+  update-main-branch:
     description: >
-      Whether or not to update the CHANGELOG & do the release in the main branch.
+      Whether or not to update the CHANGELOG in the main branch.
       If ``true``, the branch used to update the CHANGELOG is main.
       If ``false``, check the value of the update-release-branch input.
     required: false
@@ -167,7 +167,7 @@ runs:
     - name: "Set CHANGELOG update branch"
       shell: bash
       run: |
-        if [[ ${{ inputs.use-main-branch }} == "true" ]]; then
+        if [[ ${{ inputs.update-main-branch }} == "true" ]]; then
           echo "UPDATE_BRANCH=${{ env.MAIN_BRANCH }}" >> $GITHUB_ENV
           echo "RELEASE_BRANCH_EXISTS=true" >> $GITHUB_ENV
         elif [[ ${{ inputs.update-release-branch }} == "true" ]]; then
@@ -202,7 +202,7 @@ runs:
 
         if [ $count -gt 0 ]; then
           # Checkout branch from tag
-          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.use-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
+          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.update-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
             echo "Using release branch"
             git checkout ${{ env.UPDATE_BRANCH }}
             git pull
@@ -244,7 +244,7 @@ runs:
           echo "COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
           # Push CHANGELOG.md changes
-          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.use-main-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
+          if ([[ ${{ inputs.update-release-branch }} == "true" ]] || [[ ${{ inputs.update-branch }} == "true" ]]) && [[ ${{ env.RELEASE_BRANCH_EXISTS }} == "true" ]]; then
             git push
           else
             git push -u origin ${{ env.UPDATE_BRANCH }}
@@ -257,7 +257,7 @@ runs:
         fi
 
     - name: "Create PR into main with CHANGELOG changes"
-      if: ${{ (inputs.use-main-branch != 'true' ) && (env.UPDATED_CHANGELOG == 'True') }}
+      if: ${{ (inputs.update-main-branch != 'true' ) && (env.UPDATED_CHANGELOG == 'True') }}
       env:
         GH_TOKEN: ${{ inputs.token }}
       shell: bash

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -126,6 +126,15 @@ runs:
         python-version: ${{ env.PYTHON_VERSION }}
         use-cache: ${{ env.PYTHON_CACHE }}
 
+    - name: Check inputs are not both true
+      shell: bash
+      run: |
+        if [ "${{ inputs.update-release-branch }}" == "true" ] && [ "${{ inputs.update-main-branch }}" == "true" ]; then
+          echo "update-release-branch and update-main-branch cannot both be true."
+          echo "To update the main branch, set update-release-branch to false and update-main-branch to true."
+          exit 1
+        fi
+
     - name: Save tag version
       shell: bash
       run: |


### PR DESCRIPTION
Updates the changelog file and deletes the towncrier fragments on the main branch directly. This is mainly to fix these issues in the pre-commit hooks repo when doing releases: [203](https://github.com/ansys/pre-commit-hooks/issues/203), [171](https://github.com/ansys/pre-commit-hooks/issues/171)

use-main-branch: true
- [Skips creating the PR into main with the deleted towncrier fragments & updated changelog file](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149117952/job/28063309800)
- [Successful run after changelog is updated & fragment files are removed from main](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149121860/job/28063325213)

default (update-release-branch is true and use-main-branch is false)
- release/x.y branch doesn't exist
    - [Creates temporary branch to update changelog & remove towncrier fragment files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149380544/job/28064207971)
    - [Successful run after changelog update & removed towncrier files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149386961)
    - [PR into main](https://github.com/ansys-internal/actions-sandbox/pull/64/files)

- release/x.y branch exists
    - [Checks out release/x.y branch to update changelog & remove towncrier fragment files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149723205/job/28065256748)
    - [Successful run after changelog update & removed towncrier files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149729232)
    - [PR into main](https://github.com/ansys-internal/actions-sandbox/pull/65/files)
 
both update-release-branch and update-main-branch are false
- [Creates temporary branch to update changelog & remove towncrier fragment files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149887759/job/28065776463)
- [Successful run after changelog update & removed towncrier files](https://github.com/ansys-internal/actions-sandbox/actions/runs/10149896110)
- [PR into main](https://github.com/ansys-internal/actions-sandbox/pull/67/files)

both update-release-branch and update-main-branch are true (It will update the main branch)
- [Skips creating the PR into main with the deleted towncrier fragments & updated changelog file](https://github.com/ansys-internal/actions-sandbox/actions/runs/10150011089/job/28066160614)
- [Successful run after changelog is updated & fragment files are removed from main](https://github.com/ansys-internal/actions-sandbox/actions/runs/10150015971/job/28066178476)