### PR TITLE
feat: doc-changelog allow breaking changes symbol in conventional commit type

### DIFF
--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -312,7 +312,7 @@ def write_towncrier_config_section(
             file.write(f"{key} = {value}\n")
 
 
-def remove_existing_types(types, changelog_sections: list):
+def remove_existing_types(types: list, changelog_sections: list):
     """Remove the existing [[tool.towncrier.types]] from the changelog_sections list.
 
     Parameters
@@ -325,8 +325,9 @@ def remove_existing_types(types, changelog_sections: list):
     for group in types:
         # Remove changelog section if it exists under [[tool.towncrier.type]] so that
         # only missing sections are appended to the pyproject.toml file
-        if group["directory"] in changelog_sections:
-            changelog_sections.remove(group["directory"])
+        section = group["directory"]
+        if section in changelog_sections:
+            changelog_sections.remove(section)
 
 
 def write_missing_types(changelog_sections: list, file):

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -324,7 +324,7 @@ def remove_existing_types(types: list, changelog_sections: list):
     for group in types:
         # Remove changelog section if it exists under [[tool.towncrier.type]] so that
         # only missing sections are appended to the pyproject.toml file
-        section = group["directory"]
+        section = group.get("directory")
         if section in changelog_sections:
             changelog_sections.remove(section)
 

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -325,7 +325,8 @@ def remove_existing_types(types, changelog_sections: list):
     for group in types:
         # Remove changelog section if it exists under [[tool.towncrier.type]] so that
         # only missing sections are appended to the pyproject.toml file
-        changelog_sections.remove(group["directory"])
+        if group["directory"] in changelog_sections:
+            changelog_sections.remove(group["directory"])
 
 
 def write_missing_types(changelog_sections: list, file):

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -104,7 +104,8 @@ def changelog_category_cc(cc_type: str):
     for key, value in cc_type_changelog_dict.items():
         if key in cc_type:
             # Get the changelog section based on the conventional commit type
-            changelog_section = cc_type_changelog_dict[key]
+            changelog_section = value
+            break
 
     # Save the changelog section to the CHANGELOG_SECTION environment variable
     save_env_variable("CHANGELOG_SECTION", changelog_section)

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -268,8 +268,6 @@ def add_towncrier_config(org_name: str, repo_name: str, default_config: bool):
             # Get the existing [[tool.towncrier.type]] sections
             types = towncrier.get("type", "DNE")
             if types != "DNE":
-                print(types)
-                print(changelog_sections)
                 remove_existing_types(types, changelog_sections)
 
         # Add missing [[tool.towncrier.type]] sections

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -101,8 +101,10 @@ def changelog_category_cc(cc_type: str):
         "ci": "maintenance",
     }
 
-    # Get the changelog section based on the conventional commit type
-    changelog_section = cc_type_changelog_dict[cc_type]
+    for key, value in cc_type_changelog_dict.items():
+        if key in cc_type:
+            # Get the changelog section based on the conventional commit type
+            changelog_section = cc_type_changelog_dict[key]
 
     # Save the changelog section to the CHANGELOG_SECTION environment variable
     save_env_variable("CHANGELOG_SECTION", changelog_section)

--- a/doc-changelog/parse_pr_title.py
+++ b/doc-changelog/parse_pr_title.py
@@ -268,6 +268,8 @@ def add_towncrier_config(org_name: str, repo_name: str, default_config: bool):
             # Get the existing [[tool.towncrier.type]] sections
             types = towncrier.get("type", "DNE")
             if types != "DNE":
+                print(types)
+                print(changelog_sections)
                 remove_existing_types(types, changelog_sections)
 
         # Add missing [[tool.towncrier.type]] sections


### PR DESCRIPTION
Adjusted the logic to get the changelog section from the cc_type_changelog_dict when there's an exclamation point in the conventional commit type string from the PR title. It looks like amannn/action-semantic-pull-request [allows the breaking changes symbol (!)](https://github.com/amannn/action-semantic-pull-request/blob/main/README.md#examples)