### PR TITLE
chore: move the description in doc-deploy-changelog

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -30,6 +30,54 @@ description: |
 
   This action will only work on Linux/macOS runners.
 
+  Pushing a release tag results in this action running twice:
+
+  - Once to run ``towncrier`` and consolidate the changelog fragment files
+    into a single update of the CHANGELOG file.
+  - Once to release the package after the CHANGELOG file has been updated.
+
+  There are two options when making a release for your repository:
+
+  1. You pushed a tag from a release branch (``release-from-main`` is ``false``)
+
+    This is the most common case for PyAnsys repositories. The following steps are
+    performed when ``release-from-main`` is ``false``:
+
+    a) Find a release branch that has the same major and minor version of the
+    tag that was pushed. For example, if your tag was "v0.1.2", it looks for
+    a release branch named "release/0.1". If the release branch cannot be found, a
+    temporary branch is used named "maint/changelog-update-vTAG_VERSION".
+
+    b) Checkout the release or temporary branch, update the CHANGELOG file
+    using ``towncrier``, and push the updates to the respective branch.
+
+    c) Checkout the main branch and create a pull request branch named
+    "maint/vTAG_VERSION-changelog". Delete the pull request branch from the remote
+    if it exists, checkout the pull request branch, cherry pick the commit
+    containing the CHANGELOG file changes from the previous step, push the
+    pull request branch, and create a pull request from the branch into main.
+
+    d) Checkout the release or temporary branch, delete the tag locally and
+    on the remote, create the new tag locally, and push the tag on the remote.
+    Delete the temporary branch if one was used to update the CHANGELOG file.
+
+    e) Exit on error if the CHANGELOG is updated, so that the package is not released from
+    this instance of the workflow.
+
+  2. You pushed a tag from the main branch (``release-from-main`` is ``true``)
+
+    The following steps are performed when ``release-from-main`` is ``true``:
+
+    a) Checkout the main branch, update the CHANGELOG file using ``towncrier``,
+    and push the updates to the main branch.
+
+    b) Checkout the main branch, delete the tag locally and on the remote,
+    create the new tag locally, and push the new tag on the remote.
+
+    c) Exit on error if the CHANGELOG is updated, so that the package is not released from
+    this instance of the workflow.
+
+
 inputs:
   # Required inputs
 
@@ -75,54 +123,11 @@ inputs:
 
   release-from-main:
     description: |
-      Pushing a release tag results in this action running twice:
+      If ``false``, you pushed a tag from a release branch. This is applicable for most
+      PyAnsys repositories.
+      If ``true``, you pushed a tag from the main branch.
 
-      Once to run ``towncrier`` and consolidate the changelog fragments into a
-      single update of the CHANGELOG file.
-
-      Once to release the package after the CHANGELOG file has been updated.
-
-      There are two options when making a release for your repository:
-
-      1. You pushed a tag from a release branch (``release-from-main`` is ``false``)
-
-        This is the most common case for PyAnsys repositories. The following steps are
-        performed when ``release-from-main`` is ``false``:
-
-        a) Find a release branch that has the same major and minor version of the
-        tag that was pushed. For example, if your tag was "v0.1.2", it looks for
-        a release branch named "release/0.1". If the release branch cannot be found, a
-        temporary branch is used named "maint/changelog-update-vTAG_VERSION".
-
-        b) Checkout the release or temporary branch, update the CHANGELOG file
-        using ``towncrier``, and push the updates to the respective branch.
-
-        c) Checkout the main branch and create a pull request branch named
-        "maint/vTAG_VERSION-changelog". Delete the pull request branch from the remote
-        if it exists, checkout the pull request branch, cherry pick the commit
-        containing the CHANGELOG file changes from the previous step, push the
-        pull request branch, and create a pull request from the branch into main.
-
-        d) Checkout the release or temporary branch, delete the tag locally and
-        on the remote, create the new tag locally, and push the tag on the remote.
-        Delete the temporary branch if one was used to update the CHANGELOG file.
-
-        e) Exit on error if the CHANGELOG is updated, so that the package is not released from
-        this instance of the workflow.
-
-      2. You pushed a tag from the main branch (``release-from-main`` is ``true``)
-
-        The following steps are performed when ``release-from-main`` is ``true``:
-
-        a) Checkout the main branch, update the CHANGELOG file using ``towncrier``,
-        and push the updates to the main branch.
-
-        b) Checkout the main branch, delete the tag locally and on the remote,
-        create the new tag locally, and push the new tag on the remote.
-
-        c) Exit on error if the CHANGELOG is updated, so that the package is not released from
-        this instance of the workflow.
-
+      See the description for more information about each of the options.
     required: false
     default: false
     type: boolean


### PR DESCRIPTION
Move the description of the doc-deploy-changelog process to the main description and simplify the description under release-from-main