### PR TITLE
fix: needs-quarto is required parameter

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -121,10 +121,8 @@ inputs:
 
   needs-quarto:
     description: |
-      Whether to add a Quarto cheatsheet to the documentation. Default value is
-      ``false``.
-    default: false
-    required: false
+      Whether to add a Quarto cheatsheet to the documentation.
+    required: true
     type: boolean
 
 

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -113,10 +113,8 @@ inputs:
 
   needs-quarto:
     description: |
-      Whether to add a Quarto cheatsheet to the documentation. Default value is
-      ``false``.
-    default: false
-    required: false
+      Whether to add a Quarto cheatsheet to the documentation.
+    required: true
     type: boolean
 
 


### PR DESCRIPTION
While updating #543 conflict, I found out that the parameter `needs-quarto` was not correctly defined in private actions.