### PR TITLE
fix: command context when no pyproject.toml

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -219,7 +219,7 @@ runs:
     - name: "Determine make command context"
       shell: bash
       run: |
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
           echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- make')" >> $GITHUB_ENV
         else
           echo "SPHINX_BUILD_MAKE=$(echo 'make')" >> $GITHUB_ENV
@@ -285,6 +285,7 @@ runs:
           Environment variable PDF_FILENAME set to ${{ env.PDF_FILENAME }}.
 
     # ------------------------------------------------------------------------
+
     - uses: ansys/actions/_logging@main
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       with:

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -265,12 +265,11 @@ runs:
     - name: Determine command context
       shell: powershell
       run: |
-        if (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"') {
+        if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {
           echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
           echo "SPHINX_BUILD_MAKE=$(echo 'doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
-        echo "Sphinx build make value is ${{ env.SPHINX_BUILD_MAKE }}"
 
     - name: Build HTML, PDF, and JSON documentation
       shell: powershell


### PR DESCRIPTION
This PR make the `doc-build` action compatible with repos without `pyproject.toml` file. This is typically the case for repositories dedicated to example, e.g. [pymapdl-examples](https://github.com/ansys/pymapdl-examples) or  [pymechanical-examples](https://github.com/ansys/pymechanical-examples).

Close #544