### PR TITLE
fix: use powershell in quarto check (windows)

### DIFF
--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -205,7 +205,7 @@ runs:
 
     - name: Check Quarto Version
       if: ${{ inputs.needs-quarto == 'true' }}
-      shell: bash
+      shell: powershell
       run: |
         quarto --version
 


### PR DESCRIPTION
In private action `_doc-build-windows`, set step "Check Quarto Version" to use `shell: powershell` instead of `shell: bash`.
