### PR TITLE
refactor: use virtual environment to be consistent

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -272,11 +272,6 @@ runs:
           python -m pip install .[doc]
         fi
 
-    - name: "Move into doc foled"
-      shell: bash
-      run: |
-        cd doc
-
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
@@ -290,15 +285,15 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
-        ${{ env.SPHINX_BUILD_MAKE }} pdf
+        ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
+        ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
         then
-          ${{ env.SPHINX_BUILD_MAKE }} linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
+          ${{ env.SPHINX_BUILD_MAKE }} -C doc linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
         if [[ ${{ inputs.skip-json-build }} == 'false' ]];
         then
-          ${{ env.SPHINX_BUILD_MAKE }} json SPHINXOPTS="${{ inputs.sphinxopts }}"
+          ${{ env.SPHINX_BUILD_MAKE }} -C doc json SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
 
     - name: "Build HTML, PDF, and JSON documentation using xvfb"
@@ -306,15 +301,16 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
-        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} pdf
+        cd doc
+        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
+        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
         then
-          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
+          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
         if [[ ${{ inputs.skip-json-build }} == 'false' ]];
         then
-          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} json SPHINXOPTS="${{ inputs.sphinxopts }}"
+          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc json SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
 
     # ------------------------------------------------------------------------
@@ -360,7 +356,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: bash
       run: |
-        echo "EXPECTED_BUILD_DIR=_build" >> $GITHUB_ENV
+        echo "EXPECTED_BUILD_DIR=doc/_build" >> $GITHUB_ENV
 
     - name: Check expected build directory
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
@@ -436,14 +432,14 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: documentation-html
-        path: _build/html
+        path: doc/_build/html
         retention-days: 7
 
     - name: "Upload PDF documentation artifact"
       uses: actions/upload-artifact@v4
       with:
         name: documentation-pdf
-        path: _build/latex/*.pdf
+        path: doc/_build/latex/*.pdf
         retention-days: 7
 
     - name: "Upload JSON documentation artifact"
@@ -451,5 +447,5 @@ runs:
       if: inputs.skip-json-build == 'false'
       with:
         name: documentation-json
-        path: _build/json
+        path: doc/_build/json
         retention-days: 7

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -179,56 +179,111 @@ runs:
         sudo apt-get update
         sudo apt-get install -y poppler-utils
 
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Determine context.
+
+    - name: "Determine Github environnement variables"
+      shell: bash
+      run: |
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
+          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- make')" >> $GITHUB_ENV
+        else
+          echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+          echo "SPHINX_BUILD_MAKE=$(echo 'make')" >> $GITHUB_ENV
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build backend: ${{ env.BUILD_BACKEND }}
+          Sphinx build make: ${{ SPHINX_BUILD_MAKE }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Set up python to build the documentation.
+
+    - name: "Set poetry environment variable(s) (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        # For projects using poetry, do not use a virtual environment.
+        # Poetry uses virtual environments to install its dependencies, but this might
+        # lead to problems if it is not activated prior to executing poetry commands.
+        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
+        # poetry from creating a virtual environment.
+        #
+        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+
+    - name: "Update pip"
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python -m pip install -U pip
+
     - name: "Check if requirements.txt file exists"
       shell: bash
       run: |
         echo "EXISTS_DOC_REQUIREMENTS=$(if [ -f ${{ inputs.requirements-file }} ]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_ENV
 
-    - name: "Print previous output"
-      shell: bash
-      run: |
-        echo "Output was found ${{ env.EXISTS_DOC_REQUIREMENTS }}"
-
-    - name: "Update pip"
-      shell: bash
-      run: python -m pip install -U pip
-
     - name: "Install documentation dependencies from requirements file"
       shell: bash
       if: env.EXISTS_DOC_REQUIREMENTS == 'true'
       run: |
+        source .venv/bin/activate
         python -m pip install -r ${{ inputs.requirements-file }}
+
+    - name: "Install poetry (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        source .venv/bin/activate
+        python -m pip install poetry
 
     - name: "Install Python library"
       shell: bash
       if: inputs.skip-install == 'false'
       run: |
-        python -m pip install .
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
+          poetry install
+        else
+          python -m pip install .
+        fi
 
     - name: "Install documentation dependencies from pyproject.toml"
       shell: bash
       if: env.EXISTS_DOC_REQUIREMENTS == 'false'
       run: |
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
-          python -m pip install poetry
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           poetry install --with doc
         else
-          python -m pip install .[doc]
+          python -m pip install .[doc] ${{ env.PYTHON_NO_CACHE_OPTION }}
         fi
 
-    - name: "Determine make command context"
-      shell: bash
-      run: |
-        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
-          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- make')" >> $GITHUB_ENV
-        else
-          echo "SPHINX_BUILD_MAKE=$(echo 'make')" >> $GITHUB_ENV
-        fi
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build HTML, PDF and JSON documentation.
 
     - name: "Build HTML, PDF, and JSON documentation"
       if: inputs.requires-xvfb == 'false'
       shell: bash
       run: |
+        source .venv/bin/activate
         ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
         ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
@@ -244,6 +299,7 @@ runs:
       if: inputs.requires-xvfb == 'true'
       shell: bash
       run: |
+        source .venv/bin/activate
         xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
         xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
@@ -268,6 +324,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: bash
       run: |
+        source .venv/bin/activate
         python ${{ github.action_path }}/../doc-build/parse_doc_conf.py
 
     - uses: ansys/actions/_logging@main

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -203,7 +203,7 @@ runs:
         level: "INFO"
         message: >
           Build backend: ${{ env.BUILD_BACKEND }}
-          Sphinx build make: ${{ SPHINX_BUILD_MAKE }}
+          Sphinx build make: ${{ env.SPHINX_BUILD_MAKE }}
 
     # ------------------------------------------------------------------------
 

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -187,7 +187,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine GitHub environnement variables"
+    - name: "Determine GitHub environment variables"
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -272,6 +272,11 @@ runs:
           python -m pip install .[doc]
         fi
 
+    - name: "Move into doc foled"
+      shell: bash
+      run: |
+        cd doc
+
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
@@ -285,15 +290,15 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
-        ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
+        ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
+        ${{ env.SPHINX_BUILD_MAKE }} pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
         then
-          ${{ env.SPHINX_BUILD_MAKE }} -C doc linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
+          ${{ env.SPHINX_BUILD_MAKE }} linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
         if [[ ${{ inputs.skip-json-build }} == 'false' ]];
         then
-          ${{ env.SPHINX_BUILD_MAKE }} -C doc json SPHINXOPTS="${{ inputs.sphinxopts }}"
+          ${{ env.SPHINX_BUILD_MAKE }} json SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
 
     - name: "Build HTML, PDF, and JSON documentation using xvfb"
@@ -301,15 +306,15 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
-        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
+        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
+        xvfb-run ${{ env.SPHINX_BUILD_MAKE }} pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];
         then
-          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
+          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} linkcheck SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
         if [[ ${{ inputs.skip-json-build }} == 'false' ]];
         then
-          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc json SPHINXOPTS="${{ inputs.sphinxopts }}"
+          xvfb-run ${{ env.SPHINX_BUILD_MAKE }} json SPHINXOPTS="${{ inputs.sphinxopts }}"
         fi
 
     # ------------------------------------------------------------------------
@@ -355,7 +360,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: bash
       run: |
-        echo "EXPECTED_BUILD_DIR=doc/_build" >> $GITHUB_ENV
+        echo "EXPECTED_BUILD_DIR=_build" >> $GITHUB_ENV
 
     - name: Check expected build directory
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
@@ -431,14 +436,14 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: documentation-html
-        path: doc/_build/html
+        path: _build/html
         retention-days: 7
 
     - name: "Upload PDF documentation artifact"
       uses: actions/upload-artifact@v4
       with:
         name: documentation-pdf
-        path: doc/_build/latex/*.pdf
+        path: _build/latex/*.pdf
         retention-days: 7
 
     - name: "Upload JSON documentation artifact"
@@ -446,5 +451,5 @@ runs:
       if: inputs.skip-json-build == 'false'
       with:
         name: documentation-json
-        path: doc/_build/json
+        path: _build/json
         retention-days: 7

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -329,7 +329,6 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        cd doc
         xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc html SPHINXOPTS="${{ inputs.sphinxopts }}"
         xvfb-run ${{ env.SPHINX_BUILD_MAKE }} -C doc pdf
         if [[ ${{ inputs.check-links }} == 'true' ]];

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -234,7 +234,7 @@ runs:
     - name: "Set poetry environment variable(s)"
       if: env.BUILD_BACKEND == 'poetry'
       shell: bash
-      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
 
     # NOTE: Install pipx in a location that can be used in following CICD jobs
     # but ensure that poetry is installed in a temporary folder cleaned before

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -268,7 +268,7 @@ runs:
         if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           poetry install --with doc
         else
-          python -m pip install .[doc] ${{ env.PYTHON_NO_CACHE_OPTION }}
+          python -m pip install .[doc]
         fi
 
     # ------------------------------------------------------------------------

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -187,7 +187,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine Github environnement variables"
+    - name: "Determine GitHub environnement variables"
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -196,6 +196,7 @@ runs:
         else
           echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
           echo "SPHINX_BUILD_MAKE=$(echo 'make')" >> $GITHUB_ENV
+        fi
 
     - uses: ansys/actions/_logging@main
       with:

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -219,17 +219,46 @@ runs:
         message: >
           Set up python to build the documentation.
 
-    - name: "Set poetry environment variable(s) (if required)"
-      shell: bash
+    # NOTE: Installation of poetry in a separate environment to the project to
+    # avoid situations in which both poetry and the project have shared
+    # dependencies with different version. This can lead to CICD failures. For
+    # more information, see https://github.com/ansys/actions/pull/560
+    - name: "Add pipx/bin directory to Github Path"
       if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH
+
+    # NOTE: Poetry uses virtual environments when installing a project. As we
+    # want to control that creation, we store POETRY_VIRTUALENVS_CREATE=false
+    # in the GitHub environment.
+    - name: "Set poetry environment variable(s)"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+
+    # NOTE: Install pipx in a location that can be used in following CICD jobs
+    # but ensure that poetry is installed in a temporary folder cleaned before
+    # and after each job. This way poetry is kinda "installed at system level"
+    # making it available in the following call and installed in a different
+    # environment from the project.
+    - name: "Install poetry and create a virtual environment"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
       run: |
-        # For projects using poetry, do not use a virtual environment.
-        # Poetry uses virtual environments to install its dependencies, but this might
-        # lead to problems if it is not activated prior to executing poetry commands.
-        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-        # poetry from creating a virtual environment.
-        #
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+        python -m pip install pipx
+        python -m pipx install poetry
+        python -m venv .venv
+      env:
+        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
+        PIPX_HOME : ${{ runner.temp }}/pipx/home
+
+    - name: "Create a virtual environment"
+      if: env.BUILD_BACKEND == 'pip'
+      shell: bash
+      run: |
+        python -m venv .venv
+
+    # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash
@@ -248,13 +277,6 @@ runs:
       run: |
         source .venv/bin/activate
         python -m pip install -r ${{ inputs.requirements-file }}
-
-    - name: "Install poetry (if required)"
-      shell: bash
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        source .venv/bin/activate
-        python -m pip install poetry
 
     - name: "Install Python library"
       shell: bash

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -217,7 +217,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine GitHub environnement variables"
+    - name: "Determine GitHub environment variables"
       shell: powershell
       run: |
         if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -302,11 +302,6 @@ runs:
           python -m pip install .[doc]
         }
 
-    - name: "Move into doc directory"
-      shell: powershell
-      run: |
-        cd doc
-
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
@@ -319,6 +314,7 @@ runs:
       shell: powershell
       run: |
         .venv\Scripts\Activate.ps1
+        cd doc
         ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
         ${{ env.SPHINX_BUILD_MAKE }} pdf
         if ("${{ inputs.check-links }}" -eq 'true' ) {
@@ -371,7 +367,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
-        echo "EXPECTED_BUILD_DIR=$(echo '_build')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "EXPECTED_BUILD_DIR=$(echo 'doc\_build')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Check expected build directory
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
@@ -447,14 +443,14 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: documentation-html
-        path: _build/html
+        path: doc/_build/html
         retention-days: 7
 
     - name: Upload PDF documentation artifact
       uses: actions/upload-artifact@v4
       with:
         name: documentation-pdf
-        path: _build/latex/*.pdf
+        path: doc/_build/latex/*.pdf
         retention-days: 7
 
     - name: Upload JSON documentation artifact
@@ -462,5 +458,5 @@ runs:
       if: inputs.skip-json-build == 'false'
       with:
         name: documentation-json
-        path: _build/json
+        path: doc/_build/json
         retention-days: 7

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -261,7 +261,7 @@ runs:
         .venv\Scripts\Activate.ps1
         python -m pip install -U pip
 
-    - name: Check if requirements.txt file exists
+    - name: "Check if requirements.txt file exists"
       shell: powershell
       run: |
         echo "EXISTS_DOC_REQUIREMENTS=$(if (Test-Path '${{ inputs.requirements-file }}') { echo 'true' } else { echo 'false' })" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -33,8 +33,8 @@ description: |
   <https://www.sphinx-doc.org/en/master/man/sphinx-build.html>`_ is available
   after installing the documentation dependencies, the action uses it
   to generate documentation from the source. It requires that all the
-  documentation is contained in the ``doc/`` directory of a project. The
-  action locates the ``doc/make.bat`` and runs the ``make.bat html`` and
+  documentation is contained in the ``doc\`` directory of a project. The
+  action locates the ``doc\make.bat`` and runs the ``make.bat html`` and
   ``make.bat pdf`` commands. If desired, the ``make.bat json`` command can
   also be executed to generate JSON documentation.
 
@@ -100,7 +100,7 @@ inputs:
       Whether to add PDF and HTML documentation as assets of the HTML
       documentation. The HTML documentation is compressed before being added.
       The PDF file name is expected to be retrieved through the documentation's
-      configuration file 'conf.py' in 'doc/source'.
+      configuration file 'conf.py' in 'doc\source'.
 
       .. warning::
 
@@ -302,6 +302,11 @@ runs:
           python -m pip install .[doc]
         }
 
+    - name: "Move into doc directory"
+      shell: powershell
+      run: |
+        cd doc
+
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
@@ -314,7 +319,6 @@ runs:
       shell: powershell
       run: |
         .venv\Scripts\Activate.ps1
-        echo "Sphinx build make value is ${{ env.SPHINX_BUILD_MAKE }}"
         ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
         ${{ env.SPHINX_BUILD_MAKE }} pdf
         if ("${{ inputs.check-links }}" -eq 'true' ) {
@@ -367,7 +371,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
-        echo "EXPECTED_BUILD_DIR=$(echo 'doc\_build')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "EXPECTED_BUILD_DIR=$(echo '_build')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Check expected build directory
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
@@ -443,14 +447,14 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: documentation-html
-        path: doc/_build/html
+        path: _build/html
         retention-days: 7
 
     - name: Upload PDF documentation artifact
       uses: actions/upload-artifact@v4
       with:
         name: documentation-pdf
-        path: doc/_build/latex/*.pdf
+        path: _build/latex/*.pdf
         retention-days: 7
 
     - name: Upload JSON documentation artifact
@@ -458,5 +462,5 @@ runs:
       if: inputs.skip-json-build == 'false'
       with:
         name: documentation-json
-        path: doc/_build/json
+        path: _build/json
         retention-days: 7

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -225,7 +225,7 @@ runs:
           echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
           echo "BUILD_BACKEND=$(echo 'pip')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SPHINX_BUILD_MAKE=$(echo 'make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "SPHINX_BUILD_MAKE=$(echo '.\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
     - uses: ansys/actions/_logging@main

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -222,10 +222,10 @@ runs:
       run: |
         if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {
           echo "BUILD_BACKEND=$(echo 'poetry')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         } else {
           echo "BUILD_BACKEND=$(echo 'pip')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "SPHINX_BUILD_MAKE=$(echo 'doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "SPHINX_BUILD_MAKE=$(echo 'make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         }
 
     - uses: ansys/actions/_logging@main

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -274,7 +274,7 @@ runs:
         python -m pip install -r ${{ inputs.requirements-file }}
 
     - name: "Install poetry (if required)"
-      shell: bash
+      shell: powershell
       if: env.BUILD_BACKEND == 'poetry'
       run: |
         .venv\Scripts\Activate.ps1

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -215,43 +215,91 @@ runs:
       with:
         level: "INFO"
         message: >
+          Determine context.
+
+    - name: "Determine Github environnement variables"
+      shell: powershell
+      run: |
+        if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {
+          echo "BUILD_BACKEND=$(echo 'poetry')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        } else {
+          echo "BUILD_BACKEND=$(echo 'pip')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "SPHINX_BUILD_MAKE=$(echo 'doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        }
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build backend: ${{ env.BUILD_BACKEND }}
+          Sphinx build make: ${{ SPHINX_BUILD_MAKE }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
           Set up python to build the documentation.
+
+    - name: "Set poetry environment variable(s) (if required)"
+      shell: powershell
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        # For projects using poetry, do not use a virtual environment.
+        # Poetry uses virtual environments to install its dependencies, but this might
+        # lead to problems if it is not activated prior to executing poetry commands.
+        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
+        # poetry from creating a virtual environment.
+        #
+        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
 
     - name: "Update pip"
       shell: powershell
-      run: python -m pip install -U pip
+      run: |
+        .venv\Scripts\Activate.ps1
+        python -m pip install -U pip
 
     - name: Check if requirements.txt file exists
       shell: powershell
       run: |
         echo "EXISTS_DOC_REQUIREMENTS=$(if (Test-Path '${{ inputs.requirements-file }}') { echo 'true' } else { echo 'false' })" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
 
-    - name: Print previous output
-      shell: powershell
-      run: |
-        echo "Output was found ${{ env.EXISTS_DOC_REQUIREMENTS }}"
-
     - name: Install documentation dependencies from requirements file
       shell: powershell
       if: ${{ env.EXISTS_DOC_REQUIREMENTS == 'true' }}
       run: |
+        .venv\Scripts\Activate.ps1
         python -m pip install -r ${{ inputs.requirements-file }}
+
+    - name: "Install poetry (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        .venv\Scripts\Activate.ps1
+        python -m pip install poetry
 
     - name: Install Python library
       shell: powershell
       if: ${{ inputs.skip-install == 'false' }}
       run: |
-        python -m pip install .
+        .venv\Scripts\Activate.ps1
+        if ("${{ env.BUILD_BACKEND }}" -eq 'poetry' ) {
+          poetry install
+        } else {
+          python -m pip install .
+        }
 
     - name: Install documentation dependencies from pyproject.toml
       shell: powershell
       if: ${{ env.EXISTS_DOC_REQUIREMENTS == 'false' }}
       run: |
-        if (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"') {
-            python -m pip install poetry
-            poetry install --with doc
+        .venv\Scripts\Activate.ps1
+        if ("${{ env.BUILD_BACKEND }}" -eq 'poetry' ) {
+          poetry install --with doc
         } else {
-            python -m pip install .[doc]
+          python -m pip install .[doc]
         }
 
     # ------------------------------------------------------------------------
@@ -262,18 +310,10 @@ runs:
         message: >
           Build HTML, PDF and JSON documentation.
 
-    - name: Determine command context
-      shell: powershell
-      run: |
-        if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {
-          echo "SPHINX_BUILD_MAKE=$(echo 'poetry run -- doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        } else {
-          echo "SPHINX_BUILD_MAKE=$(echo 'doc\make.bat')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        }
-
     - name: Build HTML, PDF, and JSON documentation
       shell: powershell
       run: |
+        .venv\Scripts\Activate.ps1
         echo "Sphinx build make value is ${{ env.SPHINX_BUILD_MAKE }}"
         ${{ env.SPHINX_BUILD_MAKE }} html SPHINXOPTS="${{ inputs.sphinxopts }}"
         ${{ env.SPHINX_BUILD_MAKE }} pdf
@@ -297,6 +337,7 @@ runs:
       if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
+        .venv\Scripts\Activate.ps1
         python ${{ github.action_path }}\..\doc-build\parse_doc_conf.py
 
     - uses: ansys/actions/_logging@main

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -233,7 +233,7 @@ runs:
         level: "INFO"
         message: >
           Build backend: ${{ env.BUILD_BACKEND }}
-          Sphinx build make: ${{ SPHINX_BUILD_MAKE }}
+          Sphinx build make: ${{ env.SPHINX_BUILD_MAKE }}
 
     # ------------------------------------------------------------------------
 

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -217,7 +217,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine Github environnement variables"
+    - name: "Determine GitHub environnement variables"
       shell: powershell
       run: |
         if ((Test-Path "pyproject.toml") -and (Get-Content "pyproject.toml" | Select-String -Pattern 'build-backend = "poetry\.core\.masonry\.api"')) {

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -244,17 +244,45 @@ runs:
         message: >
           Set up python to build the documentation.
 
-    - name: "Set poetry environment variable(s) (if required)"
-      shell: powershell
+    # NOTE: Installation of poetry in a separate environment to the project to
+    # avoid situations in which both poetry and the project have shared
+    # dependencies with different version. This can lead to CICD failures. For
+    # more information, see https://github.com/ansys/actions/pull/560
+    - name: "Add pipx/bin directory to Github Path"
       if: env.BUILD_BACKEND == 'poetry'
+      shell: powershell
+      run: echo "${{ runner.temp }}/pipx/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    # NOTE: Poetry uses virtual environments when installing a project. As we
+    # want to control that creation, we store POETRY_VIRTUALENVS_CREATE=false
+    # in the GitHub environment.
+    - name: "Set poetry environment variable(s)"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: powershell
+      run: echo "POETRY_VIRTUALENVS_CREATE=$(echo false)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    # NOTE: Install pipx in a location that can be used in following CICD jobs
+    # but ensure that poetry is installed in a temporary folder cleaned before
+    # and after each job. This way poetry is kinda "installed at system level"
+    # making it available in the following call and installed in a different
+    # environment from the project.
+    - name: "Install poetry and create a virtual environment"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: powershell
       run: |
-        # For projects using poetry, do not use a virtual environment.
-        # Poetry uses virtual environments to install its dependencies, but this might
-        # lead to problems if it is not activated prior to executing poetry commands.
-        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-        # poetry from creating a virtual environment.
-        #
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+        python -m pip install pipx
+        python -m pipx install poetry
+        python -m venv .venv
+      env:
+        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
+        PIPX_HOME : ${{ runner.temp }}/pipx/home
+
+    - name: "Create a virtual environment"
+      if: env.BUILD_BACKEND == 'pip'
+      shell: powershell
+      run: python -m venv .venv
+
+    # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: powershell
@@ -273,13 +301,6 @@ runs:
       run: |
         .venv\Scripts\Activate.ps1
         python -m pip install -r ${{ inputs.requirements-file }}
-
-    - name: "Install poetry (if required)"
-      shell: powershell
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        .venv\Scripts\Activate.ps1
-        python -m pip install poetry
 
     - name: Install Python library
       shell: powershell

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -193,7 +193,8 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine Github environnement variables"
+    - name: "Determine GitHub environment variables"
+
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -238,7 +238,7 @@ runs:
     - name: "Set poetry environment variable(s)"
       if: env.BUILD_BACKEND == 'poetry'
       shell: bash
-      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
 
     # NOTE: Install pipx in a location that can be used in following CICD jobs
     # but ensure that poetry is installed in a temporary folder cleaned before

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -201,6 +201,7 @@ runs:
           echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
         else
           echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+        fi
 
     - uses: ansys/actions/_logging@main
       with:

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -185,22 +185,87 @@ runs:
       with:
         repository: ${{ env.DEPENDENCY_CHECK_REPOSITORY }}
 
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Determine context.
+
+    - name: "Determine Github environnement variables"
+      shell: bash
+      run: |
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
+        else
+          echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build backend: ${{ env.BUILD_BACKEND }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Set up python to check vulnerabilities.
+
+    - name: "Set poetry environment variable(s) (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        # For projects using poetry, do not use a virtual environment.
+        # Poetry uses virtual environments to install its dependencies, but this might
+        # lead to problems if it is not activated prior to executing poetry commands.
+        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
+        # poetry from creating a virtual environment.
+        #
+        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+
     - name: "Set up Python ${{ inputs.python-version }}"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: false
 
+    - name: Create virtual environment
+      shell: bash
+      run: |
+        python -m venv .venv
+
+    - name: "Update pip"
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python -m pip install -U pip
+
+    - name: "Install poetry (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        source .venv/bin/activate
+        python -m pip install poetry
+
     - name: "Install requirements"
       shell: bash
       run: |
-        python -m pip install --upgrade pip
+        source .venv/bin/activate
         pip install -r ${{ github.action_path }}/requirements.txt
 
     - name: "Install library"
       shell: bash
       run: |
-        python -m pip install .
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
+          poetry install
+        else
+          python -m pip install .
+        fi
 
     - name: "Download the list of ignored safety vulnerabilities"
       shell: bash
@@ -210,6 +275,7 @@ runs:
     - name: "Run safety and bandit"
       shell: bash
       run: |
+        source .venv/bin/activate
         # Load accepted safety vulnerabilities
         mapfile ignored_safety_vulnerabilities < ignored-safety.txt
         ignored_vulnerabilities=''
@@ -224,6 +290,7 @@ runs:
     - name: "Run safety advisory checks"
       shell: bash
       run: |
+        source .venv/bin/activate
         if [[ ${{ inputs.hide-log }} == 'true' ]]; then
           python ${{ github.action_path }}/check_vulnerabilities.py > /dev/null 2>&1
         else

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -217,41 +217,58 @@ runs:
         message: >
           Set up python to check vulnerabilities.
 
-    - name: "Set poetry environment variable(s) (if required)"
-      shell: bash
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        # For projects using poetry, do not use a virtual environment.
-        # Poetry uses virtual environments to install its dependencies, but this might
-        # lead to problems if it is not activated prior to executing poetry commands.
-        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-        # poetry from creating a virtual environment.
-        #
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-
     - name: "Set up Python ${{ inputs.python-version }}"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: false
 
-    - name: Create virtual environment
+    # NOTE: Installation of poetry in a separate environment to the project to
+    # avoid situations in which both poetry and the project have shared
+    # dependencies with different version. This can lead to CICD failures. For
+    # more information, see https://github.com/ansys/actions/pull/560
+    - name: "Add pipx/bin directory to Github Path"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH
+
+    # NOTE: Poetry uses virtual environments when installing a project. As we
+    # want to control that creation, we store POETRY_VIRTUALENVS_CREATE=false
+    # in the GitHub environment.
+    - name: "Set poetry environment variable(s)"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+
+    # NOTE: Install pipx in a location that can be used in following CICD jobs
+    # but ensure that poetry is installed in a temporary folder cleaned before
+    # and after each job. This way poetry is kinda "installed at system level"
+    # making it available in the following call and installed in a different
+    # environment from the project.
+    - name: "Install poetry and create a virtual environment"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: |
+        python -m pip install pipx
+        python -m pipx install poetry
+        python -m venv .venv
+      env:
+        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
+        PIPX_HOME : ${{ runner.temp }}/pipx/home
+
+    - name: "Create a virtual environment"
+      if: env.BUILD_BACKEND == 'pip'
       shell: bash
       run: |
         python -m venv .venv
+
+    # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash
       run: |
         source .venv/bin/activate
         python -m pip install -U pip
-
-    - name: "Install poetry (if required)"
-      shell: bash
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        source .venv/bin/activate
-        python -m pip install poetry
 
     - name: "Install requirements"
       shell: bash

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -127,28 +127,52 @@ runs:
         message: >
           Set up python to check code style.
 
-    - name: "Set poetry environment variable(s) (if required)"
-      shell: bash
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        # For projects using poetry, do not use a virtual environment.
-        # Poetry uses virtual environments to install its dependencies, but this might
-        # lead to problems if it is not activated prior to executing poetry commands.
-        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-        # poetry from creating a virtual environment.
-        #
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: Create virtual environment
+    # NOTE: Installation of poetry in a separate environment to the project to
+    # avoid situations in which both poetry and the project have shared
+    # dependencies with different version. This can lead to CICD failures. For
+    # more information, see https://github.com/ansys/actions/pull/560
+    - name: "Add pipx/bin directory to Github Path"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH
+
+    # NOTE: Poetry uses virtual environments when installing a project. As we
+    # want to control that creation, we store POETRY_VIRTUALENVS_CREATE=false
+    # in the GitHub environment.
+    - name: "Set poetry environment variable(s)"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+
+    # NOTE: Install pipx in a location that can be used in following CICD jobs
+    # but ensure that poetry is installed in a temporary folder cleaned before
+    # and after each job. This way poetry is kinda "installed at system level"
+    # making it available in the following call and installed in a different
+    # environment from the project.
+    - name: "Install poetry and create a virtual environment"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: |
+        python -m pip install pipx
+        python -m pipx install poetry
+        python -m venv .venv
+      env:
+        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
+        PIPX_HOME : ${{ runner.temp }}/pipx/home
+
+    - name: "Create a virtual environment"
+      if: env.BUILD_BACKEND == 'pip'
       shell: bash
       run: |
         python -m venv .venv
+
+    # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -111,6 +111,7 @@ runs:
           echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
         else
           echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+        fi
 
     - uses: ansys/actions/_logging@main
       with:

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -148,7 +148,7 @@ runs:
     - name: "Set poetry environment variable(s)"
       if: env.BUILD_BACKEND == 'poetry'
       shell: bash
-      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
 
     # NOTE: Install pipx in a location that can be used in following CICD jobs
     # but ensure that poetry is installed in a temporary folder cleaned before

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -104,7 +104,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine Github environnement variables"
+    - name: "Determine GitHub environment variables"
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -96,31 +96,71 @@ runs:
     - name: "Install Git and clone project"
       uses: actions/checkout@v4
 
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Determine context.
+
+    - name: "Determine Github environnement variables"
+      shell: bash
+      run: |
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
+        else
+          echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build backend: ${{ env.BUILD_BACKEND }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Set up python to check code style.
+
+    - name: "Set poetry environment variable(s) (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        # For projects using poetry, do not use a virtual environment.
+        # Poetry uses virtual environments to install its dependencies, but this might
+        # lead to problems if it is not activated prior to executing poetry commands.
+        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
+        # poetry from creating a virtual environment.
+        #
+        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: "Upgrade pip and disable virtual environment (for poetry only)"
+    - name: Create virtual environment
       shell: bash
       run: |
-        python -m pip install --upgrade pip
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
-          # For projects using poetry, do not use a virtual environment.
-          # Poetry uses virtual environments to install its dependencies, but this might
-          # lead to problems if it is not activated prior to executing poetry commands.
-          # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-          # poetry from creating a virtual environment.
-          #
-          echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-        fi
+        python -m venv .venv
+
+    - name: "Update pip"
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python -m pip install -U pip
 
     - name: "Install project (if required)"
       if: inputs.skip-install == 'false'
       shell: bash
       run: |
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           python -m pip install poetry
           python -m poetry install
         else
@@ -130,12 +170,14 @@ runs:
     - name: "Install pre-commit"
       shell: bash
       run: |
+        source .venv/bin/activate
         python -m pip install pre-commit
         pre-commit install
 
     - name: "Run pre-commit"
       shell: bash
       run: |
+        source .venv/bin/activate
         pre-commit run --all-files --show-diff-on-failure
 
     # ------------------------------------------------------------------------

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -200,7 +200,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@main
+      uses: ansys/actions/_doc-build-linux@fix/inconsistent-behavior
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
@@ -225,7 +225,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@main
+      uses: ansys/actions/_doc-build-windows@fix/inconsistent-behavior
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -191,6 +191,11 @@ runs:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
+    - name: Create virtual environment
+      shell:
+      run: |
+        python -m venv .venv
+
     # ------------------------------------------------------------------------
 
     - name: Documentation build (Linux)

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -197,11 +197,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: Create virtual environment
-      shell:
-      run: |
-        python -m venv .venv
-
     # ------------------------------------------------------------------------
 
     - name: Documentation build (Linux)

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -201,7 +201,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@main
+      uses: ansys/actions/_doc-build-linux@fix/inconsistent-behavior
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
@@ -226,7 +226,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@main
+      uses: ansys/actions/_doc-build-windows@fix/inconsistent-behavior
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -201,7 +201,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@fix/inconsistent-behavior
+      uses: ansys/actions/_doc-build-linux@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
@@ -226,7 +226,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@fix/inconsistent-behavior
+      uses: ansys/actions/_doc-build-windows@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -200,7 +200,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@fix/inconsistent-behavior
+      uses: ansys/actions/_doc-build-linux@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}
@@ -225,7 +225,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@fix/inconsistent-behavior
+      uses: ansys/actions/_doc-build-windows@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -153,7 +153,7 @@ runs:
     - name: "Set poetry environment variable(s)"
       if: env.BUILD_BACKEND == 'poetry'
       shell: bash
-      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
 
     # NOTE: Install pipx in a location that can be used in following CICD jobs
     # but ensure that poetry is installed in a temporary folder cleaned before

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -101,31 +101,71 @@ runs:
       uses: actions/checkout@v4
       if: ${{ inputs.checkout == 'true' }}
 
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Determine context.
+
+    - name: "Determine Github environnement variables"
+      shell: bash
+      run: |
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
+        else
+          echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Build backend: ${{ env.BUILD_BACKEND }}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Set up python to test.
+
+    - name: "Set poetry environment variable(s) (if required)"
+      shell: bash
+      if: env.BUILD_BACKEND == 'poetry'
+      run: |
+        # For projects using poetry, do not use a virtual environment.
+        # Poetry uses virtual environments to install its dependencies, but this might
+        # lead to problems if it is not activated prior to executing poetry commands.
+        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
+        # poetry from creating a virtual environment.
+        #
+        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
+
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: "Upgrade pip and disable virtual environment (for poetry only)"
+    - name: Create virtual environment
       shell: bash
       run: |
-        python -m pip install --upgrade pip
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
-          # For projects using poetry, do not use a virtual environment.
-          # Poetry uses virtual environments to install its dependencies, but this might
-          # lead to problems if it is not activated prior to executing poetry commands.
-          # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-          # poetry from creating a virtual environment.
-          #
-          echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-        fi
+        python -m venv .venv
+
+    - name: "Update pip"
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python -m pip install -U pip
 
     - name: "Install project (if required)"
       if: inputs.skip-install == 'false'
       shell: bash
       run: |
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           python -m pip install poetry
           poetry install
         else
@@ -152,13 +192,16 @@ runs:
     - name: "Install test dependencies from the requirements file"
       shell: bash
       if: env.EXISTS_TESTS_REQUIREMENTS == 'true'
-      run: python -m pip install -r requirements/requirements_tests.txt
+      run: |
+        source .venv/bin/activate
+        python -m pip install -r requirements/requirements_tests.txt
 
     - name: "Install test dependencies from pyproject.toml"
       shell: bash
       if: env.EXISTS_TESTS_REQUIREMENTS == 'false'
       run: |
-        if grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+        source .venv/bin/activate
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           poetry install --with tests
         else
           python -m pip install .[tests]
@@ -168,10 +211,12 @@ runs:
       if: inputs.requires-xvfb == 'false'
       shell: bash
       run: |
+        source .venv/bin/activate
         pytest ${{ inputs.pytest-markers }} ${{ inputs.pytest-extra-args }} ${{ inputs.pytest-postargs }}
 
     - name: "Executing test suite using xvfb"
       if: inputs.requires-xvfb == 'true'
       shell: bash
       run: |
+        source .venv/bin/activate
         xvfb-run pytest ${{ inputs.pytest-markers }} ${{ inputs.pytest-extra-args }} ${{ inputs.pytest-postargs }}

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -116,6 +116,7 @@ runs:
           echo "BUILD_BACKEND=$(echo 'poetry')" >> $GITHUB_ENV
         else
           echo "BUILD_BACKEND=$(echo 'pip')" >> $GITHUB_ENV
+        fi
 
     - uses: ansys/actions/_logging@main
       with:

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -150,7 +150,7 @@ runs:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: Create virtual environment
+    - name: "Create virtual environment"
       shell: bash
       run: |
         python -m venv .venv

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -132,28 +132,52 @@ runs:
         message: >
           Set up python to test.
 
-    - name: "Set poetry environment variable(s) (if required)"
-      shell: bash
-      if: env.BUILD_BACKEND == 'poetry'
-      run: |
-        # For projects using poetry, do not use a virtual environment.
-        # Poetry uses virtual environments to install its dependencies, but this might
-        # lead to problems if it is not activated prior to executing poetry commands.
-        # Store POETRY_VIRTUALENVS_CREATE=false in the GitHub environment to prevent
-        # poetry from creating a virtual environment.
-        #
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: "Create virtual environment"
+    # NOTE: Installation of poetry in a separate environment to the project to
+    # avoid situations in which both poetry and the project have shared
+    # dependencies with different version. This can lead to CICD failures. For
+    # more information, see https://github.com/ansys/actions/pull/560
+    - name: "Add pipx/bin directory to Github Path"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH
+
+    # NOTE: Poetry uses virtual environments when installing a project. As we
+    # want to control that creation, we store POETRY_VIRTUALENVS_CREATE=false
+    # in the GitHub environment.
+    - name: "Set poetry environment variable(s)"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENVs
+
+    # NOTE: Install pipx in a location that can be used in following CICD jobs
+    # but ensure that poetry is installed in a temporary folder cleaned before
+    # and after each job. This way poetry is kinda "installed at system level"
+    # making it available in the following call and installed in a different
+    # environment from the project.
+    - name: "Install poetry and create a virtual environment"
+      if: env.BUILD_BACKEND == 'poetry'
+      shell: bash
+      run: |
+        python -m pip install pipx
+        python -m pipx install poetry
+        python -m venv .venv
+      env:
+        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
+        PIPX_HOME : ${{ runner.temp }}/pipx/home
+
+    - name: "Create a virtual environment"
+      if: env.BUILD_BACKEND == 'pip'
       shell: bash
       run: |
         python -m venv .venv
+
+    # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -109,7 +109,7 @@ runs:
         message: >
           Determine context.
 
-    - name: "Determine Github environnement variables"
+    - name: "Determine GitHub environment variables"
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then


### PR DESCRIPTION
Following the work on #543, it seems that there was a need for three things:
- better handling of unexpected behavior when working with VMs, see https://github.com/ansys/actions/issues/559;
- better coherence in how we deal with `poetry` and `pip` build backends;
- better handling of the corner case where poetry and the project have shared dependencies with different versions.

This PR aims at tackling those three points by enforcing the use of a virtual environment, even when working with `poetry`.

On top of those changes, the modified actions are now "more compatible" with `poetry`. Before, the default behavior was to use `python -m pip install .` while now we detect the build backend and use `poetry` if appropriate.

> **Note**: following @Andy-Grigg comments, we use a "hack" to ensure that poetry and the project are not installed in the same environment and thus don't clash with each other if they share common dependencies with different version. The idea is to use `pipx` to install poetry in a temp folder cleaned up before and after running each job. The only side effect is for VMs as `pipx` will still be here afterward.