### PR TITLE
feat: add logging warning about bot secrets requirement for v8

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -121,6 +121,21 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }} toml==${{ inputs.toml-version }}
 
+    # TODO: remove this deprecation in ansys/actions@v9
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v8 will require bot username and email inputs in the
+          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
+          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
+          to the respective workflows and see
+          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
+          for more information.
+
+    # TODO: end
+
     - name: "Get first letter of conventional commit type"
       if: ${{ inputs.use-conventional-commits == 'true' }}
       env:

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -125,7 +125,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           Ansys Actions v8 will require bot username and email inputs in the
           ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -190,7 +190,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           Ansys Actions v8 will require bot username and email inputs in the
           ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -186,6 +186,21 @@ runs:
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }} toml==${{ inputs.toml-version }}
         python -m pip install -e .
 
+    # TODO: remove this deprecation in ansys/actions@v9
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v8 will require bot username and email inputs in the
+          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
+          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
+          to the respective workflows and see
+          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
+          for more information.
+
+    # TODO: end
+
     - name: "Get towncrier directory"
       shell: python
       run: |

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -136,7 +136,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           Ansys Actions v8 will require bot username and email inputs in the
           ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -132,6 +132,21 @@ runs:
   using: "composite"
   steps:
 
+    # TODO: remove this deprecation in ansys/actions@v9
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v8 will require bot username and email inputs in the
+          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
+          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
+          to the respective workflows and see
+          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
+          for more information.
+
+    # TODO: end
+
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -155,6 +155,21 @@ runs:
   using: "composite"
   steps:
 
+    # TODO: remove this deprecation in ansys/actions@v9
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v8 will require bot username and email inputs in the
+          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
+          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
+          to the respective workflows and see
+          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
+          for more information.
+
+    # TODO: end
+
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -159,7 +159,7 @@ runs:
 
     - uses: ansys/actions/_logging@main
       with:
-        level: "WARNING"
+        level: "ERROR"
         message: >
           Ansys Actions v8 will require bot username and email inputs in the
           ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and


### PR DESCRIPTION
Add a logging warning for the actions that will require a bot-user and bot-email as inputs for v8. I'm not sure if this is the correct way to go about it, so please let me know if there are alternatives that make more sense. Thanks!