### PR TITLE
ci: fix dependabot glob pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directories:
-      - "![requirements]**/*"
+      - "!(requirements)/**/*"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directories:
-      - "**/*"
+      - "![requirements]**/*"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
The issue with the current glob pattern for `dependabot` is that these patterns can not be in conflict between different ecosystems. That is, if two ecosystems are checking for the same file, dependabot fails, see https://github.com/ansys/actions/network/updates/20639306/jobs