### PR TITLE
chore: use trusted publisher in ci_cd

### DIFF
--- a/.ci/ansys-actions/pyproject.toml
+++ b/.ci/ansys-actions/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-actions-core"
-version = "6.2.dev0"
+version = "7.1.dev0"
 description = "A demo library for testing Ansys actions"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -138,6 +138,10 @@ jobs:
     name: "Tests"
     runs-on: ubuntu-latest
     needs: code-style
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
     steps:
 
     - name: "Install Git and clone project"
@@ -174,8 +178,7 @@ jobs:
       uses: ansys/actions/release-pypi-test@main
       with:
         library-name: ${{ env.test-library-name }}
-        twine-username: "__token__"
-        twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
+        use-trusted-publisher: true
 
   doc-deploy-dev:
     name: "Deploy developers documentation"
@@ -187,6 +190,8 @@ jobs:
         with:
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}
+            bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+            bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
   doc-index-dev:
     name: "Deploy dev index docs"
@@ -255,7 +260,8 @@ jobs:
         with:
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}
-
+            bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+            bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
   doc-index-stable:
     name: "Deploy stable docs index"


### PR DESCRIPTION
Use a trusted publisher instead of twine for releases and add the bot user & email secrets