### PR TITLE
fix: skip release to PyPI test if version exists

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -178,8 +178,17 @@ jobs:
       uses: ansys/actions/release-pypi-test@main
       with:
         library-name: ${{ env.test-library-name }}
+<<<<<<< HEAD
         use-trusted-publisher: true
         skip-existing: true
+||||||| parent of 9944a39 (fix: missing skip-existing option in trusted-publish action)
+        twine-username: "__token__"
+        twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
+        skip-existing: true
+=======
+        twine-username: "__token__"
+        twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
+>>>>>>> 9944a39 (fix: missing skip-existing option in trusted-publish action)
 
   doc-deploy-dev:
     name: "Deploy developers documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -178,17 +178,7 @@ jobs:
       uses: ansys/actions/release-pypi-test@main
       with:
         library-name: ${{ env.test-library-name }}
-<<<<<<< HEAD
         use-trusted-publisher: true
-        skip-existing: true
-||||||| parent of 9944a39 (fix: missing skip-existing option in trusted-publish action)
-        twine-username: "__token__"
-        twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
-        skip-existing: true
-=======
-        twine-username: "__token__"
-        twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
->>>>>>> 9944a39 (fix: missing skip-existing option in trusted-publish action)
 
   doc-deploy-dev:
     name: "Deploy developers documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -176,6 +176,7 @@ jobs:
         library-name: ${{ env.test-library-name }}
         twine-username: "__token__"
         twine-token: ${{ secrets.PYANSYS_PYPI_TEST_PAT }}
+        skip-existing: true
 
   doc-deploy-dev:
     name: "Deploy developers documentation"

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -142,7 +142,7 @@ runs:
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
 
     - name: "Upload artifacts to PyPI using Trusted Publisher"
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.10.1
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'true'
       with:
         repository-url: ${{ inputs.index-name }}

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -148,3 +148,4 @@ runs:
         repository-url: ${{ inputs.index-name }}
         print-hash: true
         packages-dir: ${{ inputs.library-name }}-artifacts
+        skip-existing: ${{ env.SKIP_EXISTING }}


### PR DESCRIPTION
Fixes the issues raised in https://github.com/ansys/actions/actions/runs/10960208443, where the version being pushed was already present in the Test PyPI.