### PR TITLE
ci: remove environment from test PyPI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -138,7 +138,6 @@ jobs:
     name: "Tests"
     runs-on: ubuntu-latest
     needs: code-style
-    environment: tests
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Follow up of #570 which fixed the environment used for test PyPI.
The problem with the fix is that we still end up with messages referring to the deployment in the PR discussion.

![image](https://github.com/user-attachments/assets/a7220e09-ff3c-46f8-a07f-ea191108943c)
 
This PR consists in removing the environment used in test PyPI. Note that:
- the current environment used (`tests`) is an empty shell;
- the previous one (`release`) shouldn't have been used for testing if we want to keep the protection rules.