### PR TITLE
fix(doc): branch-name-sytle action deprecation

### DIFF
--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -23,6 +23,9 @@ Version ``v8``
 
 - The ``ansys/actions/commit-style`` action has been renamed to ``ansys/actions/check-pr-title``.
 
+- The ``ansys/actions/branch-name-style`` actions has been removed in favor of
+  `GitHub rulesets <https://dev.docs.pyansys.com/how-to/repository-protection.html#branch-protection>`_.
+
 **Migration steps:**
 
 - Add the following required inputs to ``ansys/actions/doc-changelog``, ``ansys/actions/doc-deploy-changelog``,

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -10,3 +10,4 @@ towncrier
 TXT
 PyAnsys Dashboard
 robots.txt
+rulesets


### PR DESCRIPTION
We missed documenting the removal of the `branch-name-style` action in the migration guide. This needs to be cherry-picked.