### PR TITLE
chore: add caution message to doc-deploy-changelog action

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -365,7 +365,7 @@ runs:
         else
           pr_title="CHORE: update CHANGELOG for v${{ env.TAG_VERSION }}"
         fi
-        gh pr create --title "$pr_title" --body "Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}" --reviewer ${{ github.actor }}
+        gh pr create --title "$pr_title" --body "Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}\n\n> [!CAUTION]\n> Do not merge this pull request until the release has been successfully made." --reviewer ${{ github.actor }}
 
     - name: "Delete & Re-create tag"
       env:

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -365,7 +365,13 @@ runs:
         else
           pr_title="CHORE: update CHANGELOG for v${{ env.TAG_VERSION }}"
         fi
-        gh pr create --title "$pr_title" --body "Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}\n\n> [!CAUTION]\n> Do not merge this pull request until the release has been successfully made." --reviewer ${{ github.actor }}
+
+        body_msg="Update CHANGELOG for v${{ env.TAG_VERSION }} and remove .md files in ${{ env.TOWNCRIER_DIR }}.
+
+        > [!CAUTION]
+        > Do not merge this pull request until the release has been successfully made."
+
+        gh pr create --title "$pr_title" --body "$body_msg" --reviewer ${{ github.actor }}
 
     - name: "Delete & Re-create tag"
       env:


### PR DESCRIPTION
Add a caution message in the body of the PR being merged into main to not merge the PR until the release has been made

Here's a preview:
![caution_msg](https://github.com/user-attachments/assets/8669b25a-e30d-4d58-bbf9-1d2345b4b6f0)
