### PR TITLE
fix: standardize venv activation in `actions/code-style`

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -262,24 +262,33 @@ runs:
       run: |
         python -m venv .venv
 
+    - name: "Set up virtual environment activation command"
+      shell: bash
+      run: |
+        if [[ ${{ runner.os }} == 'Windows' ]]; then
+          echo "ACTIVATE_VENV=$(echo 'source .venv/scripts/activate')" >> $GITHUB_ENV
+        else
+          echo "ACTIVATE_VENV=$(echo 'source .venv/bin/activate')" >> $GITHUB_ENV
+        fi
+
     # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         python -m pip install -U pip
 
     - name: "Install requirements"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         pip install -r ${{ github.action_path }}/requirements.txt
 
     - name: "Install library"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           poetry install
         else
@@ -294,7 +303,7 @@ runs:
     - name: "Run safety and bandit"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         # Load accepted safety vulnerabilities
         mapfile ignored_safety_vulnerabilities < ignored-safety.txt
         ignored_vulnerabilities=''
@@ -309,7 +318,7 @@ runs:
     - name: "Run safety advisory checks"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         if [[ ${{ inputs.hide-log }} == 'true' ]]; then
           python ${{ github.action_path }}/check_vulnerabilities.py > /dev/null 2>&1
         else

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -183,7 +183,7 @@ runs:
       shell: bash
       run: |
         if [[ ${{ runner.os }} == 'Windows' ]]; then
-          echo "ACTIVATE_VENV=$(echo '.venv\\Scripts\\activate')" >> $GITHUB_ENV
+          echo "ACTIVATE_VENV=$(echo 'source .venv/scripts/activate')" >> $GITHUB_ENV
         else
           echo "ACTIVATE_VENV=$(echo 'source .venv/bin/activate')" >> $GITHUB_ENV
         fi

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -179,19 +179,28 @@ runs:
       run: |
         python -m venv .venv
 
+    - name: "Set up virtual environment activation command"
+      shell: bash
+      run: |
+        if [[ ${{ runner.os }} == 'Windows' ]]; then
+          echo "ACTIVATE_VENV=$(echo '.venv\\Scripts\\activate')" >> $GITHUB_ENV
+        else
+          echo "ACTIVATE_VENV=$(echo 'source .venv/bin/activate')" >> $GITHUB_ENV
+        fi
+
     # ------------------------------------------------------------------------
 
     - name: "Update pip"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         python -m pip install -U pip
 
     - name: "Install project (if required)"
       if: inputs.skip-install == 'false'
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           python -m pip install poetry
           python -m poetry install
@@ -202,14 +211,14 @@ runs:
     - name: "Install pre-commit"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         python -m pip install pre-commit
         pre-commit install
 
     - name: "Run pre-commit"
       shell: bash
       run: |
-        source .venv/bin/activate
+        ${{ env.ACTIVATE_VENV }}
         if [[ ${{ inputs.show-diff-on-failure }} == 'true' ]]; then
           pre-commit run --all-files --show-diff-on-failure
         else

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -181,7 +181,7 @@ runs:
       shell: bash
       run: |
         if [[ ${{ runner.os }} == 'Windows' ]]; then
-          echo "ACTIVATE_VENV=$(echo '.venv\\Scripts\\activate')" >> $GITHUB_ENV
+          echo "ACTIVATE_VENV=$(echo 'source .venv/scripts/activate')" >> $GITHUB_ENV
         else
           echo "ACTIVATE_VENV=$(echo 'source .venv/bin/activate')" >> $GITHUB_ENV
         fi


### PR DESCRIPTION
Similarly to the issues resolved by https://github.com/ansys/actions/pull/596, the v8 `code-style` action fails on windows runners. See https://github.com/ansys/openapi-common/actions/runs/11208266030/job/31226892848 for example.

This PR applies fixes similar to https://github.com/ansys/actions/pull/596, however that still was failing https://github.com/ansys/openapi-common/actions/runs/11234704576/job/31231061286, in a way that suggests that the virtual envrionment wasn't activated at all.

I've had to change the command from `.venv\\Scripts\\activate` to `source .venv/scripts/activate` for it to actually activate the env and get a successful run https://github.com/ansys/openapi-common/actions/runs/11234704576