### PR TITLE
fix: exit 1 when logging error messages

### DIFF
--- a/_logging/action.yml
+++ b/_logging/action.yml
@@ -57,6 +57,7 @@ runs:
       if: ${{ inputs.level == 'ERROR' && runner.os == 'Linux' }}
       run: |
         echo -e "\033[1;91m[ERROR]: ${{ inputs.message }}\033[0m"
+        exit 1
 
     - name: "Report warning message"
       shell: bash
@@ -77,6 +78,7 @@ runs:
       if: ${{ inputs.level == 'ERROR' && runner.os == 'Windows' }}
       run: |
         Write-Host "$([char]27)[91m[ERROR]: ${{ inputs.message }}$([char]27)[0m"
+        Exit 1
 
     - name: "Report warning message"
       shell: powershell

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -123,7 +123,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_logging@fix/exit-error-logging
       if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -124,6 +124,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@main
+      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"
         message: >

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -123,7 +123,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@fix/exit-error-logging
+    - uses: ansys/actions/_logging@main
       if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -124,7 +124,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@fix/exit-error-logging
-      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
+      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -188,7 +188,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_logging@fix/exit-error-logging
       if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -189,6 +189,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@main
+      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -188,7 +188,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@fix/exit-error-logging
+    - uses: ansys/actions/_logging@main
       if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -189,7 +189,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@fix/exit-error-logging
-      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
+      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -134,7 +134,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_logging@fix/exit-error-logging
       if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -135,7 +135,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@fix/exit-error-logging
-      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
+      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -135,6 +135,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@main
+      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -134,7 +134,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@fix/exit-error-logging
+    - uses: ansys/actions/_logging@main
       if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -158,7 +158,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@fix/exit-error-logging
-      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
+      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -158,6 +158,7 @@ runs:
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@main
+      if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"
         message: >

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -157,7 +157,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@fix/exit-error-logging
+    - uses: ansys/actions/_logging@main
       if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
       with:
         level: "ERROR"

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -157,7 +157,7 @@ runs:
 
     # TODO: remove this deprecation in ansys/actions@v9
 
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_logging@fix/exit-error-logging
       if: github.event.inputs.bot-user == '' || github.event.inputs.bot-email == ''
       with:
         level: "ERROR"


### PR DESCRIPTION
Add check to see if bot user or email inputs are empty. If so, log an error message & exit 1. Exiting 1 when logging an error message was applied to the _logging action.

[Exit 1 on error](https://github.com/ansys-internal/actions-sandbox/actions/runs/11278326057/job/31366557792)
[Bot secrets exist, so no error](https://github.com/ansys-internal/actions-sandbox/actions/runs/11278177040/job/31366367645)

Closes #603 