### PR TITLE
fix: install additional deps on doc-style action for rST support

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -134,6 +134,11 @@ runs:
       run: |
         python -m pip install --upgrade pip toml==${{ inputs.toml-version }}
 
+    - name: "Install docutils"
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip docutils
+
     - name: "Get towncrier directory"
       shell: python
       run: |

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -176,7 +176,7 @@ runs:
         fi
 
     - name: "Run Vale"
-      uses: errata-ai/vale-action@reviewdog
+      uses: errata-ai/vale-action@v2.1.1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:


### PR DESCRIPTION
As title says. This was modified in https://github.com/errata-ai/vale-action/commit/1262efadd6fde1040255db25589fe57804d785d2 inside the vale-action so now we need to install it manually.