### PR TITLE
fix: check step in _doc-build-windows

### DIFF
--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -379,20 +379,17 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       with:
         level: "INFO"
         message: >
           Check if expected directories exist.
 
     - name: Set expected build directory
-      if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
         echo "EXPECTED_BUILD_DIR=$(echo 'doc\_build')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Check expected build directory
-      if: ${{ inputs.add-pdf-html-docs-as-assets == 'true' }}
       shell: powershell
       run: |
         echo "EXISTS_EXPECTED_BUILD_DIR=$(if (Test-Path '${{ env.EXPECTED_BUILD_DIR }}') { echo 'true' } else { echo 'false' })" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
@@ -432,6 +429,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - name: Verify the docs have been generated properly
+      if: ${{ env.EXISTS_EXPECTED_BUILD_DIR == 'true' }}
       shell: powershell
       run: |
         # Check if the HTML files have been generated

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -226,7 +226,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@main
+      uses: ansys/actions/_doc-build-windows@fix/check-step-in-doc-build-windows
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -226,7 +226,7 @@ runs:
 
     - name: Documentation build (Windows)
       if: ${{ runner.os == 'Windows' }}
-      uses: ansys/actions/_doc-build-windows@fix/check-step-in-doc-build-windows
+      uses: ansys/actions/_doc-build-windows@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}


### PR DESCRIPTION
Ensures that `EXPECTED_BUILD_DIR` is defined even if `add-pdf-html-docs-as-assets` is `false`.
Only trigger checking if the expected doc build directory is used, aka `doc/_build`.

Close #622