### PR TITLE
ci: fix rolling release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: "Configure git"
       run: |
@@ -44,8 +46,16 @@ jobs:
 
     - name: "Remove old tags"
       run: |
+        if git tag -l | grep -q "^${{ env.X }}$"; then 
           git push --delete origin ${{ env.X }}
+        else
+          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }} does not exist, skipping deletion.\033[0m"
+        fi
+        if git tag -l | grep -q "^${{ env.X }}$"; then 
           git push --delete origin ${{ env.X }}.${{ env.Y }}
+        else
+          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion.\033[0m"
+        fi
 
     - name: "Create new tags"
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: "Configure git"
       run: |
@@ -44,8 +46,16 @@ jobs:
 
     - name: "Remove old tags"
       run: |
-        git push --delete origin ${{ env.X }} || true
-        git push --delete origin ${{ env.X }}.${{ env.Y }} || true
+        if git tag -l | grep -q "^${{ env.X }}$"; then 
+          git push --delete origin ${{ env.X }}
+        else
+          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }} does not exist, skipping deletion.\033[0m"
+        fi
+        if git tag -l | grep -q "^${{ env.X }}$"; then 
+          git push --delete origin ${{ env.X }}.${{ env.Y }}
+        else
+          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion.\033[0m"
+        fi
 
     - name: "Create new tags"
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v4
-      with:
-        fetch-tags: true
 
     - name: "Configure git"
       run: |
@@ -46,16 +44,8 @@ jobs:
 
     - name: "Remove old tags"
       run: |
-        if git tag -l | grep -q "^${{ env.X }}$"; then 
-          git push --delete origin ${{ env.X }}
-        else
-          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }} does not exist, skipping deletion.\033[0m"
-        fi
-        if git tag -l | grep -q "^${{ env.X }}$"; then 
-          git push --delete origin ${{ env.X }}.${{ env.Y }}
-        else
-          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion.\033[0m"
-        fi
+        git push --delete origin ${{ env.X }} || true
+        git push --delete origin ${{ env.X }}.${{ env.Y }} || true
 
     - name: "Create new tags"
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-tags: true
-
+        ref: ${{ github.ref }}
     - name: "Configure git"
       run: |
           git config user.name github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,12 @@ jobs:
 
     - name: "Remove old tags"
       run: |
-        if git tag -l | grep -q "^${{ env.X }}$"; then 
+        if git tag -l | grep -q "^${{ env.X }}$"; then
           git push --delete origin ${{ env.X }}
         else
           echo -e "\033[1;92m[INFO]: Tag ${{ env.X }} does not exist, skipping deletion.\033[0m"
         fi
-        if git tag -l | grep -q "^${{ env.X }}$"; then 
+        if git tag -l | grep -q "^${{ env.X }}\.${{ env.Y }}$"; then
           git push --delete origin ${{ env.X }}.${{ env.Y }}
         else
           echo -e "\033[1;92m[INFO]: Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion.\033[0m"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,12 @@ jobs:
         if git tag -l | grep -q "^${{ env.X }}$"; then
           git push --delete origin ${{ env.X }}
         else
-          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }} does not exist, skipping deletion.\033[0m"
+          echo -e "Tag ${{ env.X }} does not exist, skipping deletion."
         fi
         if git tag -l | grep -q "^${{ env.X }}\.${{ env.Y }}$"; then
           git push --delete origin ${{ env.X }}.${{ env.Y }}
         else
-          echo -e "\033[1;92m[INFO]: Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion.\033[0m"
+          echo -e "Tag ${{ env.X }}.${{ env.Y }} does not exist, skipping deletion."
         fi
 
     - name: "Create new tags"


### PR DESCRIPTION
Following the failure of release `v8.1.0`, this PR should fix the problem of performing the rolling release workflow when one didn't create the minor/major release associated. In the case of `v8.1.0`, `v8` was already existing thanks to previous workflows but that was not the case for `v8.1`. The same problem can happen with major release.

> Note: There are two commits here and they propose two approaches to handle that problem. The latest comes from @jacobevansgit and is performed in `ansys-internal` actions. The idea is to add `|| true` to the tag deletion command which ensures that the workflow won't stop even if the tag does not exist. The other approach checks tags and either perform deletion or logs an info, depending on tag existence.

Let me know which approach you prefer