### PR TITLE
feat: allow for extra targets in check-vulnerabilities action

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -70,6 +70,21 @@ inputs:
 
   # Optional inputs
 
+  extra-targets:
+    description: |
+      Extra targets to be evaluated by safety. By default, it is set to an
+      empty string. This gets substituted to the library install command as
+      follows::
+
+        # For pip install
+        pip install .[${{ inputs.extra-targets }}]
+        # For poetry install
+        poetry install --extras '${{ inputs.extra-targets }}'
+
+    default: ''
+    required: false
+    type: string
+
   source-directory:
     description: |
       The source folder of the repository to be evaluated by bandit.
@@ -289,10 +304,23 @@ runs:
       shell: bash
       run: |
         ${{ env.ACTIVATE_VENV }}
-        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
-          poetry install
+        if [[ ${{ inputs.extra-targets }} != '' ]]; then
+          if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
+            echo "Installing extra targets with poetry: ${{ inputs.extra-targets }}"
+            extra_targets=$(echo "--extras '${{ inputs.extra-targets }}'")
+          else
+            echo "Installing extra targets with pip: ${{ inputs.extra-targets }}"
+            extra_targets=$(echo"[${{ inputs.extra-targets }}]")
+          fi
         else
-          python -m pip install .
+          echo "No extra targets to install"
+          extra_targets=''
+        fi
+
+        if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
+          poetry install $extra_targets
+        else
+          python -m pip install .$extra_targets
         fi
 
     - name: "Download the list of ignored safety vulnerabilities"


### PR DESCRIPTION
Coming from an internal request by @greschd - we should allow the option to pass in extra targets to our check-vulnerabilities action.