### PR TITLE
fix: doc-deploy-changelog error handling

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -318,7 +318,6 @@ runs:
           if [ -n "$version_err" ]; then
             # Update changelog with the tag version
             buildcmd=$(towncrier build --yes --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
-            cat builderr.txt
             section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
 
             # Remove builderr.txt
@@ -330,8 +329,9 @@ runs:
               the ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert
               the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and re-run
               the workflow."
+              single_line_msg=$(echo -n "$message" | base64)
 
-              echo -e "\033[1;91m[ERROR]: $message\033[0m"
+              echo -e "\033[1;91m[ERROR]: $single_line_msg\033[0m"
               exit 1
             fi
           fi

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -310,26 +310,30 @@ runs:
           buildcmd=$(towncrier build --yes --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
           cat builderr.txt
           version_err=$(grep "Error: '--version'" builderr.txt || true)
-          section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
 
           # Remove builderr.txt
           rm builderr.txt
 
-          if [ -n "$section_exists_err" ]; then
-            # Print error message on how to fix this
-            message="Your changelog file already contains section ${{ env.TAG_VERSION }} in
-            the ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert
-            the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and re-run
-            the workflow."
-
-            echo -e "\033[1;91m[ERROR]: $message\033[0m"
-            exit 1
-          fi
-
           # If version_err contains the error message, run with the tag specified
           if [ -n "$version_err" ]; then
             # Update changelog with the tag version
-            towncrier build --yes --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}"
+            buildcmd=$(towncrier build --yes --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
+            cat builderr.txt
+            section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
+
+            # Remove builderr.txt
+            rm builderr.txt
+
+            if [ -n "$section_exists_err" ]; then
+              # Print error message on how to fix this
+              message="Your changelog file already contains section ${{ env.TAG_VERSION }} in
+              the ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert
+              the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and re-run
+              the workflow."
+
+              echo -e "\033[1;91m[ERROR]: $message\033[0m"
+              exit 1
+            fi
           fi
 
           # Configure git username & email

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -326,9 +326,9 @@ runs:
             if [ -n "$section_exists_err" ]; then
               # Print error message on how to fix this
               message="Your changelog file already contains section ${{ env.TAG_VERSION }} in the \
-              ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert \
-              the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and \
-              re-run the workflow."
+        ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert \
+        the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and \
+        re-run the workflow."
 
               echo -e "\033[1;91m[ERROR]: $message\033[0m"
               exit 1

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -309,13 +309,25 @@ runs:
           # package = "ansys.<product>.<library>"
           buildcmd=$(towncrier build --yes --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
           cat builderr.txt
-          greperr=$(grep "Error: '--version'" builderr.txt || true)
+          version_err=$(grep "Error: '--version'" builderr.txt || true)
+          section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
 
           # Remove builderr.txt
           rm builderr.txt
 
-          # If greperr contains the error message, run with the tag specified
-          if [ -n "$greperr" ]; then
+          if [ -n "$section_exists_err" ]; then
+            # Print error message on how to fix this
+            message="Your changelog file already contains section ${{ env.TAG_VERSION }} in
+            the ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert
+            the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and re-run
+            the workflow."
+
+            echo -e "\033[1;91m[ERROR]: $message\033[0m"
+            exit 1
+          fi
+
+          # If version_err contains the error message, run with the tag specified
+          if [ -n "$version_err" ]; then
             # Update changelog with the tag version
             towncrier build --yes --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}"
           fi

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -325,13 +325,12 @@ runs:
 
             if [ -n "$section_exists_err" ]; then
               # Print error message on how to fix this
-              message="Your changelog file already contains section ${{ env.TAG_VERSION }} in
-              the ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert
-              the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and re-run
-              the workflow."
-              single_line_msg=$(echo -n "$message" | base64)
+              message="Your changelog file already contains section ${{ env.TAG_VERSION }} in the \
+              ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert \
+              the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and \
+              re-run the workflow."
 
-              echo -e "\033[1;91m[ERROR]: $single_line_msg\033[0m"
+              echo -e "\033[1;91m[ERROR]: $message\033[0m"
               exit 1
             fi
           fi


### PR DESCRIPTION
Added error logging when `doc-deploy-changelog` fails with the following message:

"[ValueError: It seems you've already produced newsfiles for this version?](https://github.com/ansys/pydyna/actions/runs/11935351034/job/33267732404#step:2:634)"

Instead of displaying the above message, it will print an error message with instructions on how to fix it and exit 1:

![changelog_debug](https://github.com/user-attachments/assets/d5c6f1c0-ef8a-44ff-a250-93e8ca2f4f6b)
