### PR TITLE
feat: skip label step if coming from a forked repository

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -36,6 +36,8 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
      - name: "Label pull-request"
+       # Skip if user does not have write permissions - PR coming from a fork
+       if: github.event.pull_request.head.repo.full_name == github.repository
        uses: actions/labeler@v5.0.0
        with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
   push:
     tags:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
   push:
     tags:


### PR DESCRIPTION
Closes #645 

This will skip the label insertion if the change is coming from a forked repository... requires testing but should work.