### PR TITLE
feat: change installation order of deps in check-vulnerabilities action

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -294,12 +294,6 @@ runs:
         ${{ env.ACTIVATE_VENV }}
         python -m pip install -U pip
 
-    - name: "Install requirements"
-      shell: bash
-      run: |
-        ${{ env.ACTIVATE_VENV }}
-        pip install -r ${{ github.action_path }}/requirements.txt
-
     - name: "Install library"
       shell: bash
       # Note: we need to use an array to store the extra targets, otherwise
@@ -324,6 +318,12 @@ runs:
         else
           python -m pip install ."${extra_targets[@]}"
         fi
+
+    - name: "Install action requirements"
+      shell: bash
+      run: |
+        ${{ env.ACTIVATE_VENV }}
+        pip install -r ${{ github.action_path }}/requirements.txt
 
     - name: "Download the list of ignored safety vulnerabilities"
       shell: bash

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -323,7 +323,7 @@ runs:
       shell: bash
       run: |
         ${{ env.ACTIVATE_VENV }}
-        pip install -r ${{ github.action_path }}/requirements.txt
+        python -m pip install -r ${{ github.action_path }}/requirements.txt
 
     - name: "Download the list of ignored safety vulnerabilities"
       shell: bash


### PR DESCRIPTION
Following #646 - @greschd noticed that when using poetry and ``extra-targets`` there is a small problem... ``--with ...`` uninstalls any other deps found and thus causes setuptools not to be present, which is needed by our action to run.

By inverting the installation order, we should be able to fix this.