### PR TITLE
feat: bump default Python version to 3.11

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.11'
   DOCUMENTATION_CNAME: 'actions.docs.ansys.com'
   test-library-name: 'ansys-actions'
   MEILISEARCH_API_KEY: ${{ secrets.MEILISEARCH_API_KEY }}

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -51,7 +51,7 @@ inputs:
   python-version:
     description: |
       Python version used for installing and execution of the build process.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/check-licenses/action.yml
+++ b/check-licenses/action.yml
@@ -71,7 +71,7 @@ inputs:
   python-version:
     description: |
       Python version used for installing and executing licence check.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -163,7 +163,7 @@ inputs:
   python-version:
     description: |
       Desired Python version.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -44,7 +44,7 @@ inputs:
   python-version:
     description: |
       Python version used for installing and running ``pre-commit``.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -48,7 +48,7 @@ inputs:
   python-version:
     description: |
       Python version used for installing and running ``Sphinx``.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -57,7 +57,7 @@ inputs:
   python-version:
     description: |
       Python version used for setting up Python.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -106,7 +106,7 @@ inputs:
   python-version:
     description: |
       Python version used for setting up Python.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/doc/source/build-actions/examples/build-wheelhouse-basic.yml
+++ b/doc/source/build-actions/examples/build-wheelhouse-basic.yml
@@ -4,7 +4,7 @@ build-wheelhouse:
   strategy:
      matrix:
          os: [ubuntu-latest, windows-latest]
-         python-version: ['3.7', '3.8', '3.9', '3.10']
+         python-version: ['3.10', '3.11', '3.12', '3.13']
   steps:
     - name: "Build a wheelhouse of the Python library"
       uses: ansys/actions/build-wheelhouse@{{ version }}

--- a/doc/source/tests-actions/examples/tests-pytest-basic.yml
+++ b/doc/source/tests-actions/examples/tests-pytest-basic.yml
@@ -4,7 +4,7 @@ tests:
   strategy:
      matrix:
          os: [ubuntu-latest, windows-latest]
-         python-version: ['3.7', '3.8', '3.9', '3.10']
+         python-version: ['3.10', '3.11', '3.12', '3.13']
      fail-fast: false
   steps:
     - name: "Run pytest"

--- a/hk-package-clean-except/action.yml
+++ b/hk-package-clean-except/action.yml
@@ -48,7 +48,7 @@ inputs:
     type: string
   python-version:
     description: 'Desired Python version.'
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/hk-package-clean-untagged/action.yml
+++ b/hk-package-clean-untagged/action.yml
@@ -44,7 +44,7 @@ inputs:
     type: string
   python-version:
     description: 'Desired Python version.'
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -96,7 +96,7 @@ inputs:
       Python version for installing and using `twine
       <https://twine.readthedocs.io/en/stable/>`_.
     required: false
-    default: '3.10'
+    default: '3.11'
     type: string
 
   index-name:

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -96,7 +96,7 @@ inputs:
       Python version for installing and using `twine
       <https://twine.readthedocs.io/en/stable/>`_.
     required: false
-    default: '3.10'
+    default: '3.11'
     type: string
 
 runs:

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -88,7 +88,7 @@ inputs:
       Python version for installing and using `twine
       <https://twine.readthedocs.io/en/stable/>`_.
     required: false
-    default: '3.10'
+    default: '3.11'
     type: string
 
   skip-existing:

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -32,7 +32,7 @@ inputs:
   python-version:
     description: |
       Python version used for installing and running ``pytest``.
-    default: '3.10'
+    default: '3.11'
     required: false
     type: string
 


### PR DESCRIPTION
3.10 has been our default for a long time... since it's the next one to be dropped, let's stay one ahead.