### PR TITLE
feat: adding ``attrs`` to ignored packages

### DIFF
--- a/check-licenses/ignored-packages.txt
+++ b/check-licenses/ignored-packages.txt
@@ -1,6 +1,7 @@
 aiohappyeyeballs
 ansys-corba
 ansys-turbogrid-api
+attrs
 defusedxml
 distlib
 filelock


### PR DESCRIPTION
For some reason, ``attrs`` license is not detected, however, it is MIT license:

https://github.com/python-attrs/attrs

This was highlighted here: 

https://github.com/ansys/pymapdl/actions/runs/12349513107/job/34460488022?pr=3569#step:2:5561