### PR TITLE
docs: 'org-name' is not a variable in the code sample provided.

### DIFF
--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -226,7 +226,7 @@ Include the release notes in ``CHANGELOG.md``
 
         ## [0.10.7](https://github.com/ansys/pymechanical/releases/tag/v0.10.7) - February 13 2024
 
-3. Add the following lines to the ``pyproject.toml`` file, replacing ``{repo-name}`` with the name of the repository respectively.
+3. Add the following lines to the ``pyproject.toml`` file, replacing ``{repo-name}`` with the name of the repository.
 Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.module``. For example, ``ansys.geometry.core``.
 
 .. code:: toml

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -226,7 +226,7 @@ Include the release notes in ``CHANGELOG.md``
 
         ## [0.10.7](https://github.com/ansys/pymechanical/releases/tag/v0.10.7) - February 13 2024
 
-3. Add the following lines to the ``pyproject.toml`` file, replacing ``{org-name}`` and ``{repo-name}`` with the name of the organization and repository respectively.
+3. Add the following lines to the ``pyproject.toml`` file, replacing ``{repo-name}`` with the name of the repository respectively.
 Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.module``. For example, ``ansys.geometry.core``.
 
 .. code:: toml


### PR DESCRIPTION
In the code sample provided for the pyproject.toml section  where we add the towncrier statements, `{org-name}` does not appear to be a variable.
`ansys` is hardcoded instead.

![image](https://github.com/user-attachments/assets/da309f4b-8f03-48d7-b867-d485d1982321)


I am not against it as it might make our colleagues life easier because most of them will use ansys actions in ansys org.
It might be a slight showstopper for external people using it in an other org. But most likely limited.
Replacing `ansys` by `{org-name}` in the path would work too for me. 