### PR TITLE
fix: cache-apt-pkgs-action 1.3.1 uses upload-artifact v3 (deprecated)

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -146,7 +146,7 @@ runs:
         fi
 
     - name: "Cache apt packages needed"
-      uses: awalsh128/cache-apt-pkgs-action@v1.3.1
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       if: inputs.skip-dependencies-cache == 'false' && env.NEEDED_DEPS != ''
       with:
         packages: ${{ env.NEEDED_DEPS }}


### PR DESCRIPTION
Deprecation of actions/upload-artifact is causing failures in (for example) https://github.com/ansys/pyansys-geometry/actions/runs/12695645218/job/35388005982?pr=1617 

This affects the entire ecosystem - patch releasing right away