### PR TITLE
fix: missing shell on _doc-gen-robots workflow

### DIFF
--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -62,7 +62,7 @@ runs:
         echo -e "User-agent: *\n" >> robots.txt
 
     - name: "Iterate over all versions except the "
-      shell:
+      shell: bash
       run: |
         for version in $(ls version |
                     grep -E "^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\..*)?$" | \


### PR DESCRIPTION
Identified by the usage of zizmor. Needed resolution. Actual bug  - don't know how it even worked previously.