### PR TITLE
fix: test PyPI failing on CICD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine pkginfo packaging
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,7 +117,8 @@ jobs:
     - name: "Install build and twine"
       shell: bash
       run: |
-        python -m pip install build twine
+        python -m pip install build
+        python -m pip install twine==6.0.1
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine 'pkginfo<=1.10'
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -133,7 +133,7 @@ jobs:
         retention-days: 7
 
     - name: "Release to the test PyPI repository"
-      uses: ansys/actions/release-pypi-test@main
+      uses: ansys/actions/release-pypi-test@fix/test_py_failing
       with:
         library-name: ${{ env.test-library-name }}
         use-trusted-publisher: true

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine 'pkginfo<=1.10'
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -117,8 +117,7 @@ jobs:
     - name: "Install build and twine"
       shell: bash
       run: |
-        python -m pip install build
-        python -m pip install --upgrade twine pkginfo packaging
+        python -m pip install --upgrade pip build twine pkginfo packaging
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install twine==6.0.1
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Build distribution artifacts and check their health"
       shell: bash

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -110,7 +110,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade twine 'pkginfo<=1.10'
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -109,7 +109,8 @@ runs:
     - name: "Install twine"
       shell: bash
       run: |
-        python -m pip install --upgrade pip twine
+        python -m pip install --upgrade pip
+        python -m pip install twine==6.0.1
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -109,8 +109,7 @@ runs:
     - name: "Install twine"
       shell: bash
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade twine pkginfo packaging
+        python -m pip install --upgrade pip twine pkginfo packaging
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -110,7 +110,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine 'pkginfo<=1.10'
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -143,7 +143,7 @@ runs:
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
 
     - name: "Upload artifacts to PyPI using Trusted Publisher"
-      uses: pypa/gh-action-pypi-publish@v1.10.1
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'true'
       with:
         repository-url: ${{ inputs.index-name }}

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -110,7 +110,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install twine==6.0.1
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -142,7 +142,7 @@ runs:
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
 
     - name: "Upload artifacts to PyPI using Trusted Publisher"
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@v1.10.1
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'true'
       with:
         repository-url: ${{ inputs.index-name }}

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -110,7 +110,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine pkginfo packaging
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@v4

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine 'pkginfo<=1.10'
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine 'pkginfo<=1.10'
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -88,7 +88,8 @@ runs:
     - name: "Install build and twine"
       shell: bash
       run: |
-        python -m pip install build twine
+        python -m pip install build
+        python -m pip install twine==6.0.1
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install twine==6.0.1
+        python -m pip install --upgrade twine pkginfo
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -88,8 +88,7 @@ runs:
     - name: "Install build and twine"
       shell: bash
       run: |
-        python -m pip install build
-        python -m pip install --upgrade twine pkginfo packaging
+        python -m pip install --upgrade pip build twine pkginfo packaging
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       run: |
         python -m pip install build
-        python -m pip install --upgrade twine pkginfo
+        python -m pip install --upgrade twine pkginfo packaging
 
     - name: "Build distribution artifacts"
       shell: bash

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -104,7 +104,7 @@ runs:
   steps:
 
     - name: "Release to test PyPI index"
-      uses: ansys/actions/_release-pypi@fix/test_py_py_failing
+      uses: ansys/actions/_release-pypi@fix/test_py_failing
       with:
         library-name: ${{ inputs.library-name }}
         index-name: "https://test.pypi.org/legacy/"

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -104,7 +104,7 @@ runs:
   steps:
 
     - name: "Release to test PyPI index"
-      uses: ansys/actions/_release-pypi@main
+      uses: ansys/actions/_release-pypi@fix/test_py_py_failing
       with:
         library-name: ${{ inputs.library-name }}
         index-name: "https://test.pypi.org/legacy/"


### PR DESCRIPTION
The [Release to the test PyPI repository](https://github.com/ansys/actions/actions/runs/13431108059/job/37523090771) action is failing. This PR aims to fix it.