### PR TITLE
ci: update fake repo build system version

### DIFF
--- a/.ci/ansys-actions/pyproject.toml
+++ b/.ci/ansys-actions/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<3.11"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
Temporary work around for the problem that appeared two days ago with the release-pypi action. 