### PR TITLE
docs: fix CICD badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ graph LR
 [Ansys badge]: https://img.shields.io/badge/Ansys-ffc107.svg?labelColor=black&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
 [actions.docs.ansys.com]: https://actions.docs.ansys.com/
 [ansys/actions]: https://github.com/ansys/actions/
-[CI-CD badge]: https://github.com/ansys/actions/actions/workflows/ci_cd.yml/badge.svg
-[CI-CD yml]: https://github.com/ansys/actions/actions/workflows/ci_cd.yml
+[CI-CD badge]: https://github.com/ansys/actions/actions/workflows/ci_cd_main.yml/badge.svg
+[CI-CD yml]: https://github.com/ansys/actions/actions/workflows/ci_cd_main.yml
 [MIT badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [MIT url]: https://opensource.org/blog/license/mit
 [GitHub Workflows]: https://docs.github.com/en/actions/using-workflows/about-workflows/


### PR DESCRIPTION
Recent changes in the workflows broke the badge in our README.