### PR TITLE
ci: nightly deployment does not have the CNAME

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -7,6 +7,7 @@ on:
 env:
   MAIN_PYTHON_VERSION: '3.12'
   LIBRARY_NAME: 'ansys-actions'
+  DOCUMENTATION_CNAME: 'actions.docs.ansys.com'
 
 permissions:
   contents: write

--- a/doc/source/changelog/711.maintenance.md
+++ b/doc/source/changelog/711.maintenance.md
@@ -1,1 +1,1 @@
-nightly deploytment does not have the CNAME
+nightly deployment does not have the CNAME

--- a/doc/source/changelog/711.maintenance.md
+++ b/doc/source/changelog/711.maintenance.md
@@ -1,0 +1,1 @@
+nightly deploytment does not have the CNAME


### PR DESCRIPTION
Nightly deployment is causing our CNAME to disappear.