### PR TITLE
docs(metadata): add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+We absolutely welcome any code contributions and we hope that this guide will
+facilitate an understanding of the Ansys Actions code repository.
+
+For contributing to this project, please refer to the [PyAnsys Developer's
+Guide]. Further information about this project can be found
+in the [official docuemntation].
+
+[PyAnsys Developer's Guide]: https://dev.docs.pyansys.com
+[official documentation]: https://actions.docs.ansys.com

--- a/doc/source/changelog/712.documentation.md
+++ b/doc/source/changelog/712.documentation.md
@@ -1,0 +1,1 @@
+add CONTRIBUTING.md


### PR DESCRIPTION
Fix #581 by adding the `CONTRIBUTING.md` file. To unlock the release of ansys/actions@v8.2, the content of this file points to the PyAnsys Developer's Guide. For v9, we can expand this into a dedicated section in the documentation. 