### PR TITLE
docs: log deprecation only for trusted publishers

### DIFF
--- a/doc/source/changelog/719.documentation.md
+++ b/doc/source/changelog/719.documentation.md
@@ -1,0 +1,1 @@
+log deprecation only for trusted publishers

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -118,6 +118,7 @@ runs:
   steps:
 
     - uses: ansys/actions/_logging@main
+      if: inputs.use-trusted-publisher == 'true'
       with:
         level: "WARNING"
         message: >

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -111,6 +111,7 @@ runs:
   steps:
 
     - uses: ansys/actions/_logging@main
+      if: inputs.use-trusted-publisher == 'true'
       with:
         level: "WARNING"
         message: >

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -111,6 +111,7 @@ runs:
   steps:
 
     - uses: ansys/actions/_logging@main
+      if: inputs.use-trusted-publisher == 'true'
       with:
         level: "WARNING"
         message: >


### PR DESCRIPTION
Currently the deprecation warning is triggered even for people using the twine token approach. This should fix it.

Note that the private action `_release-pypi` has logs a "notice" if users don't leverage the trusted publisher approach so they complement each other ! :)