### PR TITLE
fix: install for Python libraries

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -133,6 +133,15 @@ inputs:
     default: true
     type: boolean
 
+  skip-install:
+    description: |
+      Whether to skip the installation of the project or not. If ``true``, the
+      project is not installed. If ``false``, the project is installed. By
+      default, the project is not installed.
+    required: false
+    default: false
+    type: boolean
+
   release-from-main:
     description: |
       If ``false``, you pushed a tag from a release branch. This is applicable for most
@@ -200,6 +209,12 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }} toml==${{ inputs.toml-version }}
+
+    - name: "Install the project"
+      shell: bash
+      if: inputs.skip-install == 'false'
+      run: |
+        python -m pip install .
 
     # TODO: remove this deprecation in ansys/actions@v9
 

--- a/doc/source/changelog/723.fixed.md
+++ b/doc/source/changelog/723.fixed.md
@@ -1,0 +1,1 @@
+install for Python libraries


### PR DESCRIPTION
As pointed out by @SMoraisAnsys, https://github.com/ansys/actions/pull/723 I removed the installation of libraries thinking this was not required. However, Towncrier requires Python projects to be installed to retrieve their current version.