### PR TITLE
fix: release-github body

### DIFF
--- a/doc/source/changelog/732.fixed.md
+++ b/doc/source/changelog/732.fixed.md
@@ -1,0 +1,1 @@
+release-github body

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -100,6 +100,13 @@ inputs:
     required: false
     type: string
 
+  pypandoc-binary-version:
+    description: |
+      Pypandoc-binary version used for converting rst text to markdown.
+    default: '1.15'
+    required: false
+    type: string
+
   changelog-release-notes:
     description: |
       Whether or not to generate release notes using the changelog file from the
@@ -279,10 +286,11 @@ runs:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: "Install toml"
+    - name: "Install toml and pypandoc"
       shell: bash
       run: |
         python -m pip install --upgrade pip toml==${{ inputs.toml-version }}
+        python -m pip install pypandoc-binary==${{ inputs.pypandoc-version }}
 
     - name: "Get the release notes body"
       if: inputs.changelog-release-notes == 'true'

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -290,7 +290,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip toml==${{ inputs.toml-version }}
-        python -m pip install pypandoc-binary==${{ inputs.pypandoc-version }}
+        python -m pip install pypandoc-binary==${{ inputs.pypandoc-binary-version }}
 
     - name: "Get the release notes body"
       if: inputs.changelog-release-notes == 'true'


### PR DESCRIPTION
Use pypandoc to convert rst content to md
- no longer need `rst_to_md_links` and `rst_to_md` functions since we are using `pypandoc.convert_text`

**Release notes body from changelog.rst file with new jinja template**
![new_jinja_template_release_notes](https://github.com/user-attachments/assets/36cf70c4-8c9c-4703-bb66-e4418e740bde)

**Release notes body from changelog.rst file with original jinja template**
![orig_jinja_template_rel_notes](https://github.com/user-attachments/assets/91e98717-a0aa-4a6a-8b63-375ab3798201)

**Release notes body from CHANGELOG.md file**
![md_jinja_template_rel_notes](https://github.com/user-attachments/assets/7a27a72e-f850-4c5a-a9fb-31f64ede50b3)