### PR TITLE
refactor: use SHA version for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "_release-pypi"
+      - "release-github"
+      # The following actions do not use non ansys-action but are added in case of future changes
+      - "release-pypi-private" 
+      - "release-pypi-public"
+      - "release-pypi-test"
     schedule:
       interval: "daily"
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,16 @@ updates:
 
   - package-ecosystem: "github-actions"
     directories:
+      - "_release-pypi"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies:ci"
+
+  - package-ecosystem: "github-actions"
+    directories:
       - "!(requirements)/**/*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "build"
+      prefix: "build(release)"
     labels:
       - "dependencies:ci"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - "_release-pypi"
       - "release-github"
       # The following actions do not use non ansys-action but are added in case of future changes
-      - "release-pypi-private" 
+      - "release-pypi-private"
       - "release-pypi-public"
       - "release-pypi-test"
     schedule:

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -148,7 +148,7 @@ runs:
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
 
     - name: "Upload artifacts to PyPI using Trusted Publisher"
-      uses: pypa/gh-action-pypi-publish@v1.10.1
+      uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'true'
       with:
         repository-url: ${{ inputs.index-name }}

--- a/doc/source/changelog/734.miscellaneous.md
+++ b/doc/source/changelog/734.miscellaneous.md
@@ -1,1 +1,1 @@
-use sha version for pypa/gh-action-pypi-publish and allow dependabot
+use SHA version for pypa/gh-action-pypi-publish

--- a/doc/source/changelog/734.miscellaneous.md
+++ b/doc/source/changelog/734.miscellaneous.md
@@ -1,0 +1,1 @@
+use sha version for pypa/gh-action-pypi-publish and allow dependabot


### PR DESCRIPTION
Use a SHA instead of a label for `pypa/gh-action-pypi-publish`.
On top of that the changes consist in adding `_release-pypi` to dependabot.
It seems that the expression `"!(requirements)/**/*"` does not cover the repo as it was assumed.