### PR TITLE
fix: correct shell expansion for pip extra targets

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -316,7 +316,7 @@ runs:
         if [[ ${{ env.BUILD_BACKEND }} == 'poetry' ]]; then
           poetry install "${extra_targets[@]}"
         else
-          python -m pip install ."${extra_targets[@]}"
+          python -m pip install ."$(echo ${extra_targets[@]} | sed 's/ /,/g')"
         fi
 
     - name: "Install action requirements"

--- a/doc/source/changelog/738.fixed.md
+++ b/doc/source/changelog/738.fixed.md
@@ -1,0 +1,1 @@
+correct shell expansion for pip extra targets


### PR DESCRIPTION
Extra targets for pip install should be comma separated.