### PR TITLE
fix: sanity check on inputs for release-github action

### DIFF
--- a/doc/source/changelog/742.fixed.md
+++ b/doc/source/changelog/742.fixed.md
@@ -1,0 +1,1 @@
+sanity check on inputs for release-github action

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -162,6 +162,16 @@ runs:
 
     # TODO: end
 
+    # Only one of both can be true: generate_release_notes, changelog-release-notes
+    - name: "Sanity check on release notes"
+      uses: ansys/actions/_logging@main
+      if: ${{ inputs.generate_release_notes == 'true' && inputs.changelog-release-notes == 'true' }}
+      with:
+        level: "ERROR"
+        message: >
+          Only one of the inputs ``generate_release_notes`` and ``changelog-release-notes``
+          can be true. Please set one of them to false.
+
     - name: "Checkout repository"
       uses: actions/checkout@v4
 


### PR DESCRIPTION
As title says. Experienced issues in https://github.com/ansys/pyansys-geometry/actions/runs/13991469373/job/39179171722