### PR TITLE
fix: ``generate_release_notes`` should be false

### DIFF
--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -140,7 +140,7 @@ inputs:
         content for the release notes body, the content will be
         pre-pended to the automatically generated notes.
 
-    default: true
+    default: false
     required: false
     type: boolean
 


### PR DESCRIPTION
Had to do a hotfix on release... this has been solved now. It was completely breaking all workflows. Should have realized that the defaults were incompatible