### PR TITLE
fix: default should be false for generate_release_notes

### DIFF
--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -140,7 +140,7 @@ inputs:
         content for the release notes body, the content will be
         pre-pended to the automatically generated notes.
 
-    default: true
+    default: false
     required: false
     type: boolean
 


### PR DESCRIPTION
As title says... attempting to fix PR issues on #744 