### PR TITLE
ci: changelog action should depend on rolling release

### DIFF
--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -81,6 +81,7 @@ jobs:
 
   changelog-deployment:
     name: "Changelog"
+    needs: rolling-release
     permissions:
       contents: write
       pull-requests: write

--- a/doc/source/changelog/750.maintenance.md
+++ b/doc/source/changelog/750.maintenance.md
@@ -1,0 +1,1 @@
+changelog action should depend on rolling release


### PR DESCRIPTION
If the changelog action and the rolling release action run at the same time, you enter race conditions and sometimes, the version might not be available for download. I suggest we put it as a dependent stage.