### PR TITLE
docs: do not check link on www.x.org/*

### DIFF
--- a/doc/source/changelog/755.documentation.md
+++ b/doc/source/changelog/755.documentation.md
@@ -1,0 +1,1 @@
+do not check link on www.x.org/*

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -103,6 +103,7 @@ linkcheck_ignore = [
     r"https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/*",
     "https://opensource.org/blog/license/mit",  # 403 - protected from bots
     r"https://github.com/ansys/.*",
+    r"https://www.x.org/*",
 ]
 
 # Auxiliary routines for automatic documentation generation


### PR DESCRIPTION
Every two weeks the servers associated to www.x.org are down and our CICD fails because we do have a reference to https://www.x.org/releases/X11R7.6/doc/man/man1/Xvfb.1.xhtml. This ~fixes~ ignores it.