### PR TITLE
fix: drop build and wheel packages

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -130,10 +130,10 @@ runs:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}
 
-    - name: "Update pip and install the build and wheel libraries"
+    - name: "Update pip"
       shell: bash
       run: |
-        python -m pip install --upgrade pip build wheel
+        python -m pip install --upgrade pip
 
     - name: "Check if specific target is requested"
       shell: bash

--- a/doc/source/changelog/756.fixed.md
+++ b/doc/source/changelog/756.fixed.md
@@ -1,0 +1,1 @@
+drop build and wheel packages


### PR DESCRIPTION
We use [pip wheel](https://github.com/ansys/actions/blob/af045ca0e768847401c655294e48fb9981f5dcb1/build-wheelhouse/action.yml#L191) for building wheels in `actions/build-wheelhouse`. `build` and `wheel` packages are not needed dependencies to be able to use `pip wheel` because "wheel" is a command option for pip in this case. 