### PR TITLE
refactor!: remove trusted publisher

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -81,30 +81,9 @@ inputs:
     required: true
     type: boolean
 
-  use-trusted-publisher:
-    description: |
-      Whether to use the OIDC token for releasing.
-      This is useful when you want to publish to PyPI through a CI/CD pipeline
-      as a Trusted Publisher. It is necessary that your repository has been authorized
-      to use Trusted Publisher's. For more information, see
-      `Using a Trusted Publisher <https://docs.pypi.org/trusted-publishers/>`_.
-
-      .. note::
-
-          ``permissions: id-token: write`` is mandatory for trusted publishing.
-
-    required: true
-    type: boolean
-
 runs:
   using: "composite"
   steps:
-
-    - name: "Notify to use trusted publisher"
-      shell: ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
-      if: inputs.use-trusted-publisher == 'false'
-      run: |
-        echo "::notice::We recommend using trusted publishers to securely publish packages on PyPI. You should consider moving to this approach."
 
     - name: "Set up Python"
       uses: ansys/actions/_setup-python@main
@@ -138,7 +117,7 @@ runs:
 
     - name: "Upload artifacts to PyPi"
       shell: bash
-      if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'false'
+      if: inputs.dry-run == 'false'
       run: |
         python -m twine upload --verbose ${{ env.SKIP_EXISTING }} ${{ inputs.library-name }}-artifacts/*.whl
         python -m twine upload --verbose ${{ env.SKIP_EXISTING }} ${{ inputs.library-name }}-artifacts/*.tar.gz
@@ -146,12 +125,3 @@ runs:
         TWINE_USERNAME: ${{ inputs.twine-username }}
         TWINE_PASSWORD: ${{ inputs.twine-token }}
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
-
-    - name: "Upload artifacts to PyPI using Trusted Publisher"
-      uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
-      if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'true'
-      with:
-        repository-url: ${{ inputs.index-name }}
-        print-hash: true
-        packages-dir: ${{ inputs.library-name }}-artifacts
-        skip-existing: ${{ env.SKIP_EXISTING }}

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -7,6 +7,82 @@ This guide provides information on new features, breaking changes, how to migrat
 from one version of the actions to another, and other upstream dependencies that
 have been updated.
 
+Version ``v9.0``
+----------------
+
+**Breaking changes:**
+
+- Use ``ansys/actions/build-wheelhouse`` or ``ansys/actions/check-licenses`` actions with Python version 3.10 or higher.
+- Remove input ``use-trusted-publisher`` from the ``ansys/actions/release-pypi-*`` actions.
+  See :doc:`release-pypi-trusted-publisher` for more information.
+
+  .. note::
+
+    The reason for the removal of input ``use-trusted-publisher`` is related to the action
+    `pypa/gh-action-pypi-publish <https://github.com/pypa/gh-action-pypi-publish>`_ which allows us to use the trusted
+    publisher. Indeed, starting with versions `v1.12.0` of this action, it is no longer possible to use it in a composite action,
+    see `pypa/gh-action-pypi-publish@v1.12.0 <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.0>`_.
+    However, we must use the latest versions of this action to upload
+    `PEP 639 licensing metadata <https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression>` to PyPI.
+    This will allow us to avoid adding upper bounds on our build system like `setuptools<=67.0.0`, `wheel<0.46.0` or
+    `flit_core >=3.2,<3.11`.
+
+**Migration Steps:**
+
+- Update input ``python-version`` to ``3.10`` or higher in the ``ansys/actions/build-wheelhouse`` action.
+
+  For example:
+
+  .. code-block:: yaml
+
+    build-wheelhouse:
+      name: Build wheelhouse
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - name: Build wheelhouse and perform smoke test
+        uses: ansys/actions/build-wheelhouse@v9
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          operating-system: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+
+- When using trusted publisher to publish to PyPI, define you own release job instead of using the
+  ``ansys/actions/release-pypi-*`` actions.
+
+  For example:
+
+  .. code-block:: yaml
+    release-public-pypi:
+      name: Release project to public PyPI
+      if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
+      needs: build-library
+      runs-on: ubuntu-latest
+      # INFO: Specifying a GitHub environment is optional but encouraged
+      environment: release
+      # INFO: Trusted publishers require these permissions
+      permissions:
+        id-token: write
+        contents: write
+      steps:
+
+        - name: "Download the library artifacts from build-library step"
+          uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+          with:
+            name: ${{ env.PACKAGE_NAME }}-artifacts
+            path: ${{ env.PACKAGE_NAME }}-artifacts
+
+        - name: "Upload artifacts to PyPI using trusted publisher"
+          uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+          with:
+            repository-url: "https://upload.pypi.org/legacy/"
+            print-hash: true
+            packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+            skip-existing: false
+
 Version ``v8.2``
 ----------------
 **New Features:**

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -63,22 +63,6 @@ inputs:
     default: ''
     type: string
 
-  use-trusted-publisher:
-    description: |
-      Whether to use the OIDC token for releasing. Default value is ``false``.
-      This is useful when you want to publish to PyPI through a CI/CD pipeline
-      as a Trusted Publisher. It is necessary that your repository has been authorized
-      to use Trusted Publisher's. For more information, see
-      `Using a Trusted Publisher <https://docs.pypi.org/trusted-publishers/>`_.
-
-      .. note::
-
-        ``permissions: id-token: write`` is mandatory for trusted publishing.
-
-    required: false
-    default: false
-    type: boolean
-
   dry-run:
     description: |
       Whether to run or not this action in testing mode. Testing mode executes
@@ -117,19 +101,6 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.use-trusted-publisher == 'true'
-      with:
-        level: "WARNING"
-        message: >
-          As the Python ecosystem is moving to project metadata version 2.4,
-          we need to use a more recent version of pypa/gh-action-pypi-publish.
-          However, this action is not compatible with composite actions.
-          Therefore, the `ansys/release-pypi-private` action is destined to
-          disappear in a future version. We invite all users to define their
-          release job manually. As an example, see
-          https://actions.docs.ansys.com/version/stable/release-actions/index.html#release-pypi-template
-
     - name: "Release to PyAnsys private index"
       uses: ansys/actions/_release-pypi@main
       with:
@@ -140,4 +111,3 @@ runs:
         python-version: ${{ inputs.python-version }}
         dry-run: ${{ inputs.dry-run }}
         skip-existing: ${{ inputs.skip-existing }}
-        use-trusted-publisher: ${{ inputs.use-trusted-publisher }}

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -110,19 +110,6 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.use-trusted-publisher == 'true'
-      with:
-        level: "WARNING"
-        message: >
-          As the python ecosystem is moving to project metadata version 2.4,
-          we need to use a more recent version of pypa/gh-action-pypi-publish.
-          However, this action is not compatible with composite actions.
-          Therefore, the `ansys/release-pypi-public` action is destined to
-          disappear in a future version. We invite all users to define their
-          release job manually. As an example, see
-          https://actions.docs.ansys.com/version/stable/release-actions/index.html#release-pypi-template
-
     - name: "Release to the public PyPI index"
       uses: ansys/actions/_release-pypi@main
       with:
@@ -133,4 +120,3 @@ runs:
         python-version: ${{ inputs.python-version }}
         dry-run: ${{ inputs.dry-run }}
         skip-existing: ${{ inputs.skip-existing }}
-        use-trusted-publisher: ${{ inputs.use-trusted-publisher }}

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -110,19 +110,6 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
-      if: inputs.use-trusted-publisher == 'true'
-      with:
-        level: "WARNING"
-        message: >
-          As the Python ecosystem is moving to project metadata version 2.4,
-          we need to use a more recent version of pypa/gh-action-pypi-publish.
-          However, this action is not compatible with composite actions.
-          Therefore, the `ansys/release-pypi-test` action is destined to
-          disappear in a future version. We invite all users to define their
-          release job manually. As an example, see
-          https://actions.docs.ansys.com/version/stable/release-actions/index.html#release-pypi-template
-
     - name: "Release to test PyPI index"
       uses: ansys/actions/_release-pypi@main
       with:
@@ -133,4 +120,3 @@ runs:
         python-version: ${{ inputs.python-version }}
         dry-run: ${{ inputs.dry-run }}
         skip-existing: ${{ inputs.skip-existing }}
-        use-trusted-publisher: ${{ inputs.use-trusted-publisher }}


### PR DESCRIPTION
Remove trusted publisher input from our PyPI release actions.
Add documentation on that on the migration file (also adding the wheel-house breaking change).