### PR TITLE
fix: github-ref

### DIFF
--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -51,7 +51,7 @@ jobs:
         V_AND_MAJOR=${{ env.V_AND_MAJOR }}
         MAJOR="${V_AND_MAJOR#v}"
         echo "MAJOR=${MAJOR}" >> $GITHUB_ENV
-        if [[ $GITHUB_REF_NAME != "refs/heads/release/$MAJOR.${{ env.MINOR }}" ]]; then
+        if [[ $GITHUB_REF != "refs/heads/release/$MAJOR.${{ env.MINOR }}" ]]; then
           echo "::error::Tag ${{ github.ref_name }} does not match branch version. wrong branch."
           exit 1
         fi

--- a/doc/source/changelog/764.fixed.md
+++ b/doc/source/changelog/764.fixed.md
@@ -1,0 +1,1 @@
+github-ref


### PR DESCRIPTION
GITHUB_REF and GITHUB_REF_NAME have values following `refs/heads/feature-branch-1` and `feature-branch-1` formats.