### PR TITLE
docs: fix link

### DIFF
--- a/doc/source/changelog/769.documentation.md
+++ b/doc/source/changelog/769.documentation.md
@@ -1,0 +1,1 @@
+fix link

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -25,7 +25,7 @@ Version ``v9.0``
     a composite action, see
     `pypa/gh-action-pypi-publish@v1.12.0 <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.0>`_.
     However, the latest versions of this action is required to upload
-    `PEP 639 licensing metadata <https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression>`
+    `PEP 639 licensing metadata <https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression>`_
     to PyPI. This allows to avoid adding upper bounds on build system like ``setuptools<=67.0.0``, ``wheel<0.46.0`` or ``flit_core>=3.2,<3.11``.
 
 **Migration Steps:**

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -16,17 +16,15 @@ Version ``v9.0``
 - To use ``check-licenses: true`` with the ``ansys/actions/build-wheelhouse`` action, use Python version 3.10 or higher.
 - Update your workflow to not use ``use-trusted-publisher: true`` with our pypi release actions.
 
-  .. warning::
-
-    Using the trusted publisher approach in ansys pypi release actions is not possible anymore.
-    The reason for that is related to the action
+    Using the trusted publisher approach in ``ansys/release-pypi-public`` and ``ansys/release-pypi-private`` actions is
+    not possible anymore. The reason for that is related to the action
     `pypa/gh-action-pypi-publish <https://github.com/pypa/gh-action-pypi-publish>`_ which allows to use the trusted
-    publisher. Indeed, starting with versions `v1.12.0` of this action, it is no longer possible to use the action in
-    a composite action, see
+    publisher. Indeed, it is no longer possible to use the action in a composite action for versions after ``v1.12.0``, see
     `pypa/gh-action-pypi-publish@v1.12.0 <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.0>`_.
     However, the latest versions of this action is required to upload
     `PEP 639 licensing metadata <https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression>`_
-    to PyPI. This allows to avoid adding upper bounds on build system like ``setuptools<=67.0.0``, ``wheel<0.46.0`` or ``flit_core>=3.2,<3.11``.
+    to PyPI. This allows to avoid adding upper bounds on build system like ``setuptools<=67.0.0``, ``wheel<0.46.0`` or
+    ``flit_core>=3.2,<3.11``.
 
 **Migration Steps:**
 

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -16,7 +16,7 @@ Version ``v9.0``
 - To use ``check-licenses: true`` with the ``ansys/actions/build-wheelhouse`` action, use Python version 3.10 or higher.
 - Update your workflow to not use ``use-trusted-publisher: true`` with our pypi release actions.
 
-.. warning::
+  .. warning::
 
     Using the trusted publisher approach in ``ansys/release-pypi-public`` and ``ansys/release-pypi-private`` actions is
     not possible anymore. The reason for that is related to the action

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -16,6 +16,8 @@ Version ``v9.0``
 - To use ``check-licenses: true`` with the ``ansys/actions/build-wheelhouse`` action, use Python version 3.10 or higher.
 - Update your workflow to not use ``use-trusted-publisher: true`` with our pypi release actions.
 
+.. warning::
+
     Using the trusted publisher approach in ``ansys/release-pypi-public`` and ``ansys/release-pypi-private`` actions is
     not possible anymore. The reason for that is related to the action
     `pypa/gh-action-pypi-publish <https://github.com/pypa/gh-action-pypi-publish>`_ which allows to use the trusted


### PR DESCRIPTION
As title says. We should do a patch release so that the docs get updated on the released version too.