### PR TITLE
feat: check environment approval

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Test
         run: |
           echo "::notice::Environment name ${{ job.environment.name }}"
+          echo "::notice::Environment name ${{ needs.block-dependabot-automated-runs.outputs.environment }}"
 
   labeler:
     name: "Labels"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Decide which environment should be used
         id: block
         uses: ansys/actions/check-environment-approval@main
-        with:
-          skip-manual-check-environment: ''
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Decide which environment should be used
         id: block
         uses: ansys/actions/determine-environment-approval@feat/determine-environment-approval
+        with:
+          skip-manual-check-environment: ''
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -36,7 +36,7 @@ jobs:
     needs: [determine-environment-approval]
     name: Manual approval (on dependabot PRs)
     runs-on: ubuntu-latest
-    environment: ${{ needs.block-dependabot-automated-runs.outputs.environment }}
+    environment: ${{ needs.determine-environment-approval.outputs.environment }}
     steps:
       - name: Proceed after approval
         if: ${{ job.environment.name == 'dependabot'}}

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/determine-environment-approval@feat/determine-environment-approval
+        uses: ansys/actions/determine-environment-approval@feat/determine-environment-approval
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -39,8 +39,13 @@ jobs:
     environment: ${{ needs.block-dependabot-automated-runs.outputs.environment }}
     steps:
       - name: Proceed after approval
+        if: ${{ job.environment.name == 'dependabot'}}
         run: |
           echo "::notice::Workflow approved."
+      - name: Proceed after approval
+        if: ${{ job.environment.name == 'no-dependabot'}}
+        run: |
+          echo "::notice::Workflow approval skipped."
 
   labeler:
     name: "Labels"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/check-environment-approval@feat/determine-environment-approval
+        uses: ansys/actions/check-environment-approval@main
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -27,7 +27,7 @@ jobs:
         id: block
         uses: ansys/actions/determine-environment-approval@main
         with:
-          skip-manual-check-environment: ''
+          skip-manual-check-environment: dependabot
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Test
         run: |
           echo "::notice::Environment name ${{ job.environment.name }}"
-          echo "::notice::Environment name ${{ needs.block-dependabot-automated-runs.outputs.environment }}"
+          echo "::notice::Environment name ${{ needs.determine-environment-approval.outputs.environment }}"
 
   labeler:
     name: "Labels"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/check-environment-approval@feat/determine-environment-approval
+        uses: ansys/actions/check-environment-approval@main
         with:
-          skip-manual-check-environment: 'dependabot'
+          skip-manual-check-environment: ''
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: actions/determine-environment-approval@feat/determine-environment-approval
+        uses: ansys/determine-environment-approval@feat/determine-environment-approval
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -17,31 +17,21 @@ concurrency:
 
 jobs:
 
+  determine-environment-approval:
+    name: Determine environment approval
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.block.outputs.environment }}
+    steps:
+      - name: Decide which environment should be used
+        id: block
+        uses: actions/determine-environment-approval@feat/determine-environment-approval
+
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update
   # could execute arbitrary code in our build environment.
   # Dependabot PRs must be reviewed carefully and approved manually before
   # running the CI.
-  block-dependabot-automated-runs:
-    name: Block dependabot automated runs
-    runs-on: ubuntu-latest
-    outputs:
-      environment: ${{ steps.block.outputs.environment }}
-    steps:
-      - name: Block if dependabot triggered the workflow
-        id: block
-        run: |
-          if [[ "${{ github.triggering_actor }}" == "dependabot[bot]" ]]; then
-            echo "environment=dependabot" >> "$GITHUB_OUTPUT"
-            echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
-          elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && ${{ startsWith(github.head_ref, 'dependabot/') }} ]]; then
-            echo "environment=dependabot" >> "$GITHUB_OUTPUT"
-            echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
-          else
-            echo "environment=no-dependabot" >> "$GITHUB_OUTPUT"
-            echo "::notice::Workflow triggered by ${{ github.triggering_actor }}."
-          fi
-
   check-dependabot-pr:
     needs: [block-dependabot-automated-runs]
     name: Manual approval (on dependabot PRs)

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -39,17 +39,13 @@ jobs:
     environment: ${{ needs.determine-environment-approval.outputs.environment }}
     steps:
       - name: Proceed after approval
-        if: ${{ job.environment.name == 'dependabot'}}
+        if: ${{ needs.determine-environment-approval.outputs.environment == 'dependabot'}}
         run: |
           echo "::notice::Workflow approved."
       - name: Approval skipped
-        if: ${{ job.environment.name == 'no-dependabot'}}
+        if: ${{ needs.determine-environment-approval.outputs.environment == 'no-dependabot'}}
         run: |
           echo "::notice::Workflow approval skipped."
-      - name: Test
-        run: |
-          echo "::notice::Environment name ${{ job.environment.name }}"
-          echo "::notice::Environment name ${{ needs.determine-environment-approval.outputs.environment }}"
 
   labeler:
     name: "Labels"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -33,7 +33,7 @@ jobs:
   # Dependabot PRs must be reviewed carefully and approved manually before
   # running the CI.
   check-dependabot-pr:
-    needs: [block-dependabot-automated-runs]
+    needs: [determine-environment-approval]
     name: Manual approval (on dependabot PRs)
     runs-on: ubuntu-latest
     environment: ${{ needs.block-dependabot-automated-runs.outputs.environment }}

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -27,7 +27,7 @@ jobs:
         id: block
         uses: ansys/actions/determine-environment-approval@main
         with:
-          skip-manual-check-environment: dependabot
+          skip-manual-check-environment: ''
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/check-environment-approval@feat/determine-environment-approval
+        uses: ansys/actions/check-environment-approval@main
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "::notice::Workflow approved."
       - name: Approval skipped
-        if: ${{ needs.determine-environment-approval.outputs.environment == ''}}
+        if: ${{ needs.check-environment-approval.outputs.environment == ''}}
         run: |
           echo "::notice::Workflow approval skipped."
 

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -17,17 +17,17 @@ concurrency:
 
 jobs:
 
-  determine-environment-approval:
-    name: Determine environment approval
+  check-environment-approval:
+    name: Check environment approval
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.block.outputs.environment }}
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/determine-environment-approval@main
+        uses: ansys/actions/check-environment-approval@feat/determine-environment-approval
         with:
-          skip-manual-check-environment: ''
+          skip-manual-check-environment: 'dependabot'
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update
@@ -35,17 +35,17 @@ jobs:
   # Dependabot PRs must be reviewed carefully and approved manually before
   # running the CI.
   check-dependabot-pr:
-    needs: [determine-environment-approval]
+    needs: [check-environment-approval]
     name: Manual approval (on dependabot PRs)
     runs-on: ubuntu-latest
-    environment: ${{ needs.determine-environment-approval.outputs.environment }}
+    environment: ${{ needs.check-environment-approval.outputs.environment }}
     steps:
       - name: Proceed after approval
-        if: ${{ needs.determine-environment-approval.outputs.environment == 'dependabot'}}
+        if: ${{ needs.check-environment-approval.outputs.environment == 'dependabot'}}
         run: |
           echo "::notice::Workflow approved."
       - name: Approval skipped
-        if: ${{ needs.determine-environment-approval.outputs.environment == 'no-dependabot' || needs.determine-environment-approval.outputs.environment == ''}}
+        if: ${{ needs.determine-environment-approval.outputs.environment == ''}}
         run: |
           echo "::notice::Workflow approval skipped."
 

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -42,10 +42,13 @@ jobs:
         if: ${{ job.environment.name == 'dependabot'}}
         run: |
           echo "::notice::Workflow approved."
-      - name: Proceed after approval
+      - name: Approval skipped
         if: ${{ job.environment.name == 'no-dependabot'}}
         run: |
           echo "::notice::Workflow approval skipped."
+      - name: Test
+        run: |
+          echo "::notice::Environment name ${{ job.environment.name }}"
 
   labeler:
     name: "Labels"

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/check-environment-approval@main
+        uses: ansys/actions/check-environment-approval@feat/determine-environment-approval
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Decide which environment should be used
         id: block
-        uses: ansys/actions/determine-environment-approval@feat/determine-environment-approval
+        uses: ansys/actions/determine-environment-approval@main
         with:
           skip-manual-check-environment: ''
 

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo "::notice::Workflow approved."
       - name: Approval skipped
-        if: ${{ needs.determine-environment-approval.outputs.environment == 'no-dependabot'}}
+        if: ${{ needs.determine-environment-approval.outputs.environment == 'no-dependabot' || needs.determine-environment-approval.outputs.environment == ''}}
         run: |
           echo "::notice::Workflow approval skipped."
 

--- a/check-environment-approval/action.yml
+++ b/check-environment-approval/action.yml
@@ -84,7 +84,7 @@ runs:
         if [[ "${{ github.triggering_actor }}" == "dependabot[bot]" ]]; then
           echo "environment=${{ inputs.manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
-        elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && ${{ startsWith(github.head_ref, 'dependabot/') }} ]]; then
+        elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && "${{ startsWith(github.head_ref, 'dependabot/') }}" == "true" ]]; then
           echo "environment=${{ inputs.manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
         else

--- a/check-environment-approval/action.yml
+++ b/check-environment-approval/action.yml
@@ -60,7 +60,7 @@ inputs:
       Name of the environment used to skip the manual checking. This is useful
       when the workflow is triggered by a different actor than dependabot.
     required: false
-    default: 'no-dependabot'
+    default: ''
     type: string
 
 outputs:

--- a/check-environment-approval/action.yml
+++ b/check-environment-approval/action.yml
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-name: Determine Environment Approval
+name: Check Environment Approval
 
 description: |
   Evaluates the pull request workflow and determines the environment name to be

--- a/check-environment-approval/action.yml
+++ b/check-environment-approval/action.yml
@@ -40,10 +40,13 @@ description: |
   .. note::
 
     This action relies on the
-    `github context <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context>`_
-    to determine which environment to use. The manual approval is added by configuring a
-    `github environment <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#about-environments>`_
-    requesting manual approval and using it in the workflow.
+    `Github context <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context>`_
+    to determine which environment to use. The manual approval can be added by
+    referencing the
+    `Github environment <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#about-environments>`_
+    in a workflow job and configuring the environment with deployment protection
+    rules requiring a manual approval. For more information, see how to add
+    `required reviewers <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#required-reviewers>`_.
 
 inputs:
 

--- a/determine-environment-approval/action.yml
+++ b/determine-environment-approval/action.yml
@@ -1,0 +1,95 @@
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Determine Environment Approval
+
+description: |
+  Evaluates the pull request workflow and determines the environment name to be
+  used in the workflow. The environment name should then be used in a workflow
+  to trigger a manual approval step if needed.
+
+  The environment name is set to the ``manual-check-environment`` input if
+  the workflow is triggered by ``dependabot[bot]`` or if the pull request was
+  created by ``dependabot[bot]`` and ``pyansys-ci-bot`` is the actor triggering
+  the workflow. Otherwise, it is set to ``skip-manual-check-environment`` input.
+
+  The manual check is required to mitigate supply chain attacks, where a malicious
+  dependency update could execute arbitrary code in our build environment.
+  Dependabot PRs must be reviewed carefully and approved manually before
+  running the CI.
+
+  .. note::
+
+    This action relies on the
+    `github context <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context>`_
+    to determine which environment to use. The manual approval is added by configuring a
+    `github environment <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#about-environments>`_
+    requesting manual approval and using it in the workflow.
+
+inputs:
+
+  # Optional inputs
+
+  manual-check-environment:
+    description: Name of the environment used to trigger manual checking.
+    required: false
+    default: 'dependabot'
+    type: string
+
+  skip-manual-check-environment:
+    description: |
+      Name of the environment used to skip the manual checking. This is useful
+      when the workflow is triggered by a different actor than dependabot.
+    required: false
+    default: 'no-dependabot'
+    type: string
+
+outputs:
+
+  environment:
+    description: |
+      Name of the environment used in the workflow. When a manual check is
+      required, the environment name is set to ``manual-check-environment``
+      input. Otherwise, it is set to the ``skip-manuel-check-environment``
+      input.
+    value: ${{ steps.decision.outputs.environment }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Decide which environment should be used
+      id: decision
+      shell: bash
+      run: |
+        if [[ "${{ github.triggering_actor }}" == "dependabot[bot]" ]]; then
+          echo "environment=${{ inputs.manual-check-environment }}" >> "$GITHUB_OUTPUT"
+          echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
+        elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && ${{ startsWith(github.head_ref, 'dependabot/') }} ]]; then
+          echo "environment=${{ inputs.manual-check-environment }}" >> "$GITHUB_OUTPUT"
+          echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
+        else
+          echo "environment=${{ inputs.skip-manuel-check-environment }}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Workflow triggered by ${{ github.triggering_actor }}."
+        fi
+        echo "::notice::Environment name proposed: '${environment}'"
+

--- a/determine-environment-approval/action.yml
+++ b/determine-environment-approval/action.yml
@@ -91,5 +91,5 @@ runs:
           echo "environment=${{ inputs.skip-manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::notice::Workflow triggered by ${{ github.triggering_actor }}."
         fi
-        echo "::notice::Environment name proposed: '${environment}'"
+        echo "::notice::Environment name proposed: ${{ steps.decision.outputs.environment }}"
 

--- a/determine-environment-approval/action.yml
+++ b/determine-environment-approval/action.yml
@@ -91,5 +91,3 @@ runs:
           echo "environment=${{ inputs.skip-manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::notice::Workflow triggered by ${{ github.triggering_actor }}."
         fi
-        echo "::notice::Environment name proposed: ${{ steps.decision.outputs.environment }}"
-

--- a/determine-environment-approval/action.yml
+++ b/determine-environment-approval/action.yml
@@ -69,7 +69,7 @@ outputs:
     description: |
       Name of the environment used in the workflow. When a manual check is
       required, the environment name is set to ``manual-check-environment``
-      input. Otherwise, it is set to the ``skip-manuel-check-environment``
+      input. Otherwise, it is set to the ``skip-manual-check-environment``
       input.
     value: ${{ steps.decision.outputs.environment }}
 
@@ -88,7 +88,7 @@ runs:
           echo "environment=${{ inputs.manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
         else
-          echo "environment=${{ inputs.skip-manuel-check-environment }}" >> "$GITHUB_OUTPUT"
+          echo "environment=${{ inputs.skip-manual-check-environment }}" >> "$GITHUB_OUTPUT"
           echo "::notice::Workflow triggered by ${{ github.triggering_actor }}."
         fi
         echo "::notice::Environment name proposed: '${environment}'"

--- a/doc/source/changelog/776.added.md
+++ b/doc/source/changelog/776.added.md
@@ -1,1 +1,1 @@
-determine environment approval
+check environment approval

--- a/doc/source/changelog/776.added.md
+++ b/doc/source/changelog/776.added.md
@@ -1,0 +1,1 @@
+determine environment approval

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -12,13 +12,13 @@ check-dependabot-pr:
   needs: [determine-environment-approval]
   name: Manual approval (on dependabot PRs)
   runs-on: ubuntu-latest
-  environment: ${{ needs.determine-environment-approval.outputs.environment }}
+  environment: ${{ '{{' }} needs.determine-environment-approval.outputs.environment {{ '}}' }}
   steps:
     - name: Proceed after approval
-      if: ${{ needs.determine-environment-approval.outputs.environment == 'dependabot'}}
+      if: ${{ '{{' }} needs.determine-environment-approval.outputs.environment == 'dependabot' {{ '}}' }}
       run: |
         echo "::notice::Workflow approved."
     - name: Approval skipped
-      if: ${{ needs.determine-environment-approval.outputs.environment == ''}}
+      if: ${{ '{{' }} needs.determine-environment-approval.outputs.environment == '' {{ '}}' }}
       run: |
         echo "::notice::Workflow approval skipped."

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -1,12 +1,12 @@
-determine-environment-approval:
-  name: Determine environment approval
+check-environment-approval:
+  name: Check environment approval
   runs-on: ubuntu-latest
   outputs:
     environment: ${{ steps.block.outputs.environment }}
   steps:
     - name: Decide which environment should be used
       id: block
-      uses: ansys/actions/determine-environment-approval@{{ version }}
+      uses: ansys/actions/check-environment-approval@{{ version }}
       with:
         skip-manual-check-environment: ''
 

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -7,8 +7,6 @@ check-environment-approval:
     - name: Decide which environment should be used
       id: block
       uses: ansys/actions/check-environment-approval@{{ version }}
-      with:
-        skip-manual-check-environment: ''
 
 check-dependabot-pr:
   needs: [determine-environment-approval]

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -2,7 +2,7 @@ check-environment-approval:
   name: Check environment approval
   runs-on: ubuntu-latest
   outputs:
-    environment: ${{ steps.block.outputs.environment }}
+    environment: ${{ '{{' }} steps.block.outputs.environment {{ '}}' }}
   steps:
     - name: Decide which environment should be used
       id: block

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -1,0 +1,26 @@
+determine-environment-approval:
+  name: Determine environment approval
+  runs-on: ubuntu-latest
+  outputs:
+    environment: ${{ steps.block.outputs.environment }}
+  steps:
+    - name: Decide which environment should be used
+      id: block
+      uses: ansys/actions/determine-environment-approval@{{ version }}
+      with:
+        skip-manual-check-environment: ''
+
+check-dependabot-pr:
+  needs: [determine-environment-approval]
+  name: Manual approval (on dependabot PRs)
+  runs-on: ubuntu-latest
+  environment: ${{ needs.determine-environment-approval.outputs.environment }}
+  steps:
+    - name: Proceed after approval
+      if: ${{ needs.determine-environment-approval.outputs.environment == 'dependabot'}}
+      run: |
+        echo "::notice::Workflow approved."
+    - name: Approval skipped
+      if: ${{ needs.determine-environment-approval.outputs.environment == ''}}
+      run: |
+        echo "::notice::Workflow approval skipped."

--- a/doc/source/vulnerability-actions/examples/check-environment-approval.yml
+++ b/doc/source/vulnerability-actions/examples/check-environment-approval.yml
@@ -9,16 +9,16 @@ check-environment-approval:
       uses: ansys/actions/check-environment-approval@{{ version }}
 
 check-dependabot-pr:
-  needs: [determine-environment-approval]
+  needs: [check-environment-approval]
   name: Manual approval (on dependabot PRs)
   runs-on: ubuntu-latest
-  environment: ${{ '{{' }} needs.determine-environment-approval.outputs.environment {{ '}}' }}
+  environment: ${{ '{{' }} needs.check-environment-approval.outputs.environment {{ '}}' }}
   steps:
     - name: Proceed after approval
-      if: ${{ '{{' }} needs.determine-environment-approval.outputs.environment == 'dependabot' {{ '}}' }}
+      if: ${{ '{{' }} needs.check-environment-approval.outputs.environment == 'dependabot' {{ '}}' }}
       run: |
         echo "::notice::Workflow approved."
     - name: Approval skipped
-      if: ${{ '{{' }} needs.determine-environment-approval.outputs.environment == '' {{ '}}' }}
+      if: ${{ '{{' }} needs.check-environment-approval.outputs.environment == '' {{ '}}' }}
       run: |
         echo "::notice::Workflow approval skipped."

--- a/doc/source/vulnerability-actions/index.rst
+++ b/doc/source/vulnerability-actions/index.rst
@@ -38,3 +38,13 @@ Check vulnerabilities action
 
 .. jinja:: check-vulnerabilities
     :file: _templates/action.rst.jinja
+
+Check environment approval
+--------------------------
+This action is used to determine whether a manual approval step is needed in the
+workflow. It evaluates the pull request workflow and determines the environment
+name to be used in the workflow. The environment name should then be used in a
+workflow to trigger a manual approval step if needed.
+
+.. jinja:: check-environment-approval
+    :file: _templates/action.rst.jinja

--- a/doc/source/vulnerability-actions/index.rst
+++ b/doc/source/vulnerability-actions/index.rst
@@ -44,7 +44,7 @@ Check environment approval
 This action is used to determine whether a manual approval step is needed in the
 workflow. It evaluates the pull request workflow and determines the environment
 name to be used in the workflow. The environment name should then be used in a
-workflow to trigger a manual approval step if needed.
+workflow job to trigger a manual approval step if needed.
 
 .. jinja:: check-environment-approval
     :file: _templates/action.rst.jinja


### PR DESCRIPTION
Following recent developments to add a manual approval for dependabot PR (see #751 and #774), this PR gathers the decision logic of requiring a manual approval or not.
The action allows user to specify which environment they want to use when a workflow is running because either `dependabot[bot]` triggered it or the workflow is associated to a PR of `dependabot[bot]` and `pyansys-ci-bot` is the one triggering the workflow.  Another input is allowed to provide a "skip" environment for other cases.

> [!NOTE]
Currently, passing `skip-manual-check-environment: ''` behaves as if no environment was defined. Therefore, no comment such as the one below appear in the PR conversation.
![image](https://github.com/user-attachments/assets/adfa4beb-4996-404f-95a9-62375d222c23)
That was tested in a1d92c8, see below
![image](https://github.com/user-attachments/assets/9a5f479b-4c7d-44e8-a15b-9bee69aa74ac)

