### PR TITLE
build(actions): update action-gh-release

### DIFF
--- a/doc/source/changelog/777.dependencies.md
+++ b/doc/source/changelog/777.dependencies.md
@@ -1,0 +1,1 @@
+update action-gh-release

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -348,10 +348,7 @@ runs:
         } >> "$GITHUB_ENV"
 
     - name: "Release to GitHub"
-      # NOTE: There is only one tag associated to v1 (previous version used) and it's also v0.1.15
-      # Since the V1.0.0 is not associated to a github release, the version pinned is v0.1.15
-      # This should be updated soon and this comment should be removed afterward.
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       env:
         REPO_NAME: ${{ github.event.repository.name }}
       if: inputs.dry-run == 'false'


### PR DESCRIPTION
When using the full hash for actions commit I left the old version that was used hoping for an automatic update from dependabot.
However, it seems that the action repo does not always handle new versions as one would expect (e.g. there is no 1.0 version). I checked and the only "big change" was that they moved to `node20` so I'm not expecting any issue with bumping to a newer version.