### PR TITLE
fix: dependabot checks

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${{ github.triggering_actor }}" == "dependabot[bot]" ]]; then
             echo "environment=dependabot" >> "$GITHUB_OUTPUT"
             echo "::warning::Dependabot is not allowed to trigger this workflow. Please review carefully the changes before running the workflow manually."
-          elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && ${{ startsWith(github.head_ref, 'dependabot/') }} ]]; then
+          elif [[ "${{ github.triggering_actor }}" == "pyansys-ci-bot" && "${{ startsWith(github.head_ref, 'dependabot/') }}" == "true" ]]; then
             echo "environment=dependabot" >> "$GITHUB_OUTPUT"
             echo "::warning::PyAnsys CI bot is not allowed to trigger this workflow in dependabot's PR. Please review carefully the changes before running the workflow manually."
           else

--- a/doc/source/changelog/778.fixed.md
+++ b/doc/source/changelog/778.fixed.md
@@ -1,0 +1,1 @@
+dependabot checks


### PR DESCRIPTION
Even if `${{ startsWith(github.head_ref, 'dependabot/') }}` evaluates to "false", it is still considered `truthy` in the context of bash if-statements since it is just a string to bash. We need to explicitly compare the values. Maybe I have misunderstood the intent here?

Related to #774 