### PR TITLE
chore: add upper bound on marshmallow

### DIFF
--- a/check-vulnerabilities/requirements.txt
+++ b/check-vulnerabilities/requirements.txt
@@ -1,4 +1,5 @@
 bandit>=1.7,<2
 click>=7.0,<9
+marshmallow>=3.0,<4 # There is currently a bug in marshmallow 4.0.0 that causes safety to fail
 pygithub>=1.59,<2
 safety>=2.3,<4

--- a/doc/source/changelog/780.maintenance.md
+++ b/doc/source/changelog/780.maintenance.md
@@ -1,0 +1,1 @@
+add upper bound on marshmallow


### PR DESCRIPTION
Avoid using marshmallow v4.0.0 otherwise running safety ends up with an exception being triggered:

`Unhandled exception happened: post_dump() got an unexpected keyword argument 'pass_many'`

Here is a failing workflow: https://github.com/ansys/pyacp/actions/runs/14518929119/job/40734794587

Note that this is affecting multiple projects and not only PyACP