### PR TITLE
fix: skip installation on doc-deploy-changelog

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -239,6 +239,7 @@ runs:
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
 
+
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -137,9 +137,18 @@ inputs:
     description: |
       Whether to skip the installation of the project or not. If ``true``, the
       project is not installed. If ``false``, the project is installed. By
-      default, the project is not installed.
+      default, the project is installed.
     required: false
     default: false
+    type: boolean
+
+  skip-deps-install:
+    description: |
+      Whether to skip the installation of the project's dependencies or not. If ``true``, the
+      dependencies are not installed. If ``false``, the dependencies are installed. By
+      default, the project dependencies are NOT installed.
+    required: false
+    default: true
     type: boolean
 
   release-from-main:
@@ -214,7 +223,13 @@ runs:
       shell: bash
       if: inputs.skip-install == 'false'
       run: |
-        python -m pip install .
+        if [[ ${{ inputs.skip-deps-install }} == 'false' ]]; then
+          # Install the project and its dependencies
+          python -m pip install .
+        else
+          # Install the project without its dependencies
+          python -m pip install . --no-deps
+        fi
 
     # TODO: remove this deprecation in ansys/actions@v9
 
@@ -239,7 +254,7 @@ runs:
         import os
         import toml
 
-        # Identify towncrier configuration file
+        # Identify towncrier configuration file
         pyproject_file = pathlib.Path("pyproject.toml")
         towncrier_file = pathlib.Path("towncrier.toml")
         if not pyproject_file.exists() and not towncrier_file.exists():

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -240,6 +240,7 @@ runs:
             project_name = config["tool"]["towncrier"].get("package")
         
         # If the project name is not specified, use the project name from the pyproject.toml
+        # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
             project_name = config["project"].get("name", "DNE")
 

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -133,24 +133,6 @@ inputs:
     default: true
     type: boolean
 
-  skip-install:
-    description: |
-      Whether to skip the installation of the project or not. If ``true``, the
-      project is not installed. If ``false``, the project is installed. By
-      default, the project is installed.
-    required: false
-    default: false
-    type: boolean
-
-  skip-deps-install:
-    description: |
-      Whether to skip the installation of the project's dependencies or not. If ``true``, the
-      dependencies are not installed. If ``false``, the dependencies are installed. By
-      default, the project dependencies are NOT installed.
-    required: false
-    default: true
-    type: boolean
-
   release-from-main:
     description: |
       If ``false``, you pushed a tag from a release branch. This is applicable for most
@@ -219,18 +201,6 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier==${{ inputs.towncrier-version }} toml==${{ inputs.toml-version }}
 
-    - name: "Install the project"
-      shell: bash
-      if: inputs.skip-install == 'false'
-      run: |
-        if [[ ${{ inputs.skip-deps-install }} == 'false' ]]; then
-          # Install the project and its dependencies
-          python -m pip install .
-        else
-          # Install the project without its dependencies
-          python -m pip install . --no-deps
-        fi
-
     # TODO: remove this deprecation in ansys/actions@v9
 
     - uses: ansys/actions/_logging@main
@@ -247,7 +217,7 @@ runs:
 
     # TODO: end
 
-    - name: "Get towncrier directory"
+    - name: "Get towncrier directory and project name"
       shell: python
       run: |
         import pathlib
@@ -267,13 +237,19 @@ runs:
         with open(towncrier_config, 'r') as f:
             config = toml.load(f)
             directory = config["tool"]["towncrier"]["directory"]
+            project_name = config["tool"]["towncrier"].get("package")
+        
+        # If the project name is not specified, use the project name from the pyproject.toml
+        if project_name is None:
+            project_name = config["project"].get("name", "DNE")
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')
 
-        # Append the TOWNCRIER_DIR with its value to GITHUB_ENV
+        # Append the TOWNCRIER_DIR and TOWNCRIER_NAME with its value to GITHUB_ENV
         with open(github_env, "a") as f:
             f.write(f"TOWNCRIER_DIR={directory}")
+            f.write(f"TOWNCRIER_NAME={project_name}")
 
     - name: "Get main branch name"
       shell: bash
@@ -342,36 +318,23 @@ runs:
             git pull
           fi
 
-          # Update the changelog with the package version from pyproject.toml
-          # The [tool.towncrier] section in pyproject.toml requires the following line
-          # for the command to work:
-          # package = "ansys.<product>.<library>"
-          buildcmd=$(towncrier build --yes --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
-          cat builderr.txt
-          version_err=$(grep "Error: '--version'" builderr.txt || true)
+          # Run towncrier with the tag specified
+          # Update changelog with the tag version
+          buildcmd=$(towncrier build --yes --name ${{ env.TOWNCRIER_NAME }} --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
+          section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
 
           # Remove builderr.txt
           rm builderr.txt
 
-          # If version_err contains the error message, run with the tag specified
-          if [ -n "$version_err" ]; then
-            # Update changelog with the tag version
-            buildcmd=$(towncrier build --yes --version ${{ env.TAG_VERSION }} --date "${{ env.CURRENT_DATE }}" >> builderr.txt 2>&1 || true)
-            section_exists_err=$(grep "already produced newsfiles for this version" builderr.txt || true)
-
-            # Remove builderr.txt
-            rm builderr.txt
-
-            if [ -n "$section_exists_err" ]; then
-              # Print error message on how to fix this
-              message="Your changelog file already contains section ${{ env.TAG_VERSION }} in the \
+          if [ -n "$section_exists_err" ]; then
+            # Print error message on how to fix this
+            message="Your changelog file already contains section ${{ env.TAG_VERSION }} in the \
         ${{ env.UPDATE_BRANCH }} branch. Please checkout ${{ env.UPDATE_BRANCH }}, revert \
         the commit named 'chore: updating CHANGELOG for v${{ env.TAG_VERSION }}', and \
         re-run the workflow."
 
-              echo -e "\033[1;91m[ERROR]: $message\033[0m"
-              exit 1
-            fi
+            echo -e "\033[1;91m[ERROR]: $message\033[0m"
+            exit 1
           fi
 
           # Configure git username & email

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -238,7 +238,7 @@ runs:
             config = toml.load(f)
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
-        
+
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:

--- a/doc/source/changelog/782.fixed.md
+++ b/doc/source/changelog/782.fixed.md
@@ -1,0 +1,1 @@
+skip installation on doc-deploy-changelog


### PR DESCRIPTION
We shouldn't need to install the project -- we can benefit directly from the version and name inputs.

Related to #723 -- not necessary anymore.

Closes #779 