### PR TITLE
fix: add package key in towncrier.toml

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -243,7 +243,7 @@ runs:
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
-            project_name = config["project"].get("name", "DNE")
+            project_name = config.get("project", {"name": "DNE"}).get("name", "DNE")  # Bullet-proof package name retrieval
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc/source/changelog/783.fixed.md
+++ b/doc/source/changelog/783.fixed.md
@@ -1,0 +1,1 @@
+add package key in towncrier.toml

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,5 @@
 [tool.towncrier]
-name = "ansys-actions"
-package = "ansys-actions"
+package = "ansys.actions"
 package_dir  = ".ci/ansys-actions/src"
 directory = "doc/source/changelog"
 filename = "doc/source/changelog.rst"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,7 @@
 [tool.towncrier]
 name = "ansys-actions"
 package = "ansys-actions"
+package_dir  = ".ci/ansys-actions/src"
 directory = "doc/source/changelog"
 filename = "doc/source/changelog.rst"
 template = "doc/source/changelog/template"

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,6 @@
 [tool.towncrier]
 name = "ansys-actions"
+package = "ansys-actions"
 directory = "doc/source/changelog"
 filename = "doc/source/changelog.rst"
 template = "doc/source/changelog/template"


### PR DESCRIPTION
Fix the issues raised in https://github.com/ansys/actions/actions/runs/14574889354/job/40878852430 by adding the necessary keys in the `towncrier.toml` file.