### PR TITLE
fix: Add newline between environment variables in Python

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -239,15 +239,15 @@ runs:
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
 
-        echo "TOWNCRIER_DIR: $directory"
-        echo "PROJECT_NAME: $project_name"
+        echo "TOWNCRIER_DIR $directory"
+        echo "PROJECT_NAME $project_name"
 
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
             project_name = config.get("project", {"name": "DNE"}).get("name", "DNE")  # Bullet-proof package name retrieval
 
-        echo "PROJECT_NAME: $project_name"
+        echo "PROJECT_NAME $project_name"
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -239,15 +239,15 @@ runs:
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
 
-        echo "TOWNCRIER_DIR $directory"
-        echo "PROJECT_NAME $project_name"
+        print(f"TOWNCRIER_DIR: {directory}")
+        print(f"TOWNCRIER_NAME: {project_name}")
 
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
             project_name = config.get("project", {"name": "DNE"}).get("name", "DNE")  # Bullet-proof package name retrieval
 
-        echo "PROJECT_NAME $project_name"
+        print(f"TOWNCRIER_NAME: {project_name}")
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -254,7 +254,7 @@ runs:
 
         # Append the TOWNCRIER_DIR and TOWNCRIER_NAME with its value to GITHUB_ENV
         with open(github_env, "a") as f:
-            f.write(f"TOWNCRIER_DIR={directory}")
+            f.write(f"TOWNCRIER_DIR={directory}\n")
             f.write(f"TOWNCRIER_NAME={project_name}")
 
     - name: "Get main branch name"

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -239,11 +239,15 @@ runs:
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
 
+        echo "TOWNCRIER_DIR: $directory"
+        echo "PROJECT_NAME: $project_name"
 
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
             project_name = config.get("project", {"name": "DNE"}).get("name", "DNE")  # Bullet-proof package name retrieval
+
+        echo "PROJECT_NAME: $project_name"
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -239,15 +239,10 @@ runs:
             directory = config["tool"]["towncrier"]["directory"]
             project_name = config["tool"]["towncrier"].get("package")
 
-        print(f"TOWNCRIER_DIR: {directory}")
-        print(f"TOWNCRIER_NAME: {project_name}")
-
         # If the project name is not specified, use the project name from the pyproject.toml
         # Last resource - just call it DNE. In any case, based on our template, this value is not used
         if project_name is None:
             project_name = config.get("project", {"name": "DNE"}).get("name", "DNE")  # Bullet-proof package name retrieval
-
-        print(f"TOWNCRIER_NAME: {project_name}")
 
         # Get the GITHUB_ENV variable
         github_env = os.getenv('GITHUB_ENV')

--- a/doc/source/changelog/784.fixed.md
+++ b/doc/source/changelog/784.fixed.md
@@ -1,1 +1,1 @@
-Add newline between env variables in Python
+Add newline between environment variables in Python

--- a/doc/source/changelog/784.fixed.md
+++ b/doc/source/changelog/784.fixed.md
@@ -1,0 +1,1 @@
+Add newline between env variables in Python


### PR DESCRIPTION
Newline between `TOWNCRIER_DIR` and `TOWNCRIER_NAME` was missing, causing the `TOWNCRIER_DIR` env variable's value to be `doc/source/changelogTOWNCRIER_NAME=ansys.actions.core`