### PR TITLE
fix: pin quarto version

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -171,7 +171,7 @@ runs:
       uses: quarto-dev/quarto-actions/setup@9e48da27e184aa238fcb49f5db75469626d43adb # v2.1.9
       with:
         tinytex: true
-        version: '1.6.43'
+        version: 1.6.43
 
     - name: Check Quarto Version
       if: ${{ inputs.needs-quarto == 'true' }}

--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -171,6 +171,7 @@ runs:
       uses: quarto-dev/quarto-actions/setup@9e48da27e184aa238fcb49f5db75469626d43adb # v2.1.9
       with:
         tinytex: true
+        version: '1.6.43'
 
     - name: Check Quarto Version
       if: ${{ inputs.needs-quarto == 'true' }}

--- a/_doc-build-windows/action.yml
+++ b/_doc-build-windows/action.yml
@@ -186,7 +186,7 @@ runs:
       if: ${{ inputs.needs-quarto == 'true' }}
       shell: powershell
       run: |
-        choco install quarto -y
+        choco install quarto --version=1.6.43 -y
         echo "C:\ProgramData\chocolatey\lib\quarto\tools" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
     # ------------------------------------------------------------------------

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -201,7 +201,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@main
+      uses: ansys/actions/_doc-build-linux@fix/pin-quarto-version
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -201,7 +201,7 @@ runs:
 
     - name: Documentation build (Linux)
       if: ${{ runner.os == 'Linux' }}
-      uses: ansys/actions/_doc-build-linux@fix/pin-quarto-version
+      uses: ansys/actions/_doc-build-linux@main
       with:
         sphinxopts: ${{ inputs.sphinxopts }}
         dependencies: ${{ inputs.dependencies }}

--- a/doc/source/changelog/791.fixed.md
+++ b/doc/source/changelog/791.fixed.md
@@ -1,0 +1,1 @@
+pin quarto version


### PR DESCRIPTION
Quarto v1.7.29 that workflows recently started installing is causing failures, examples:
https://github.com/ansys/pymapdl/actions/runs/14711086308/job/41283486237?pr=3875
https://github.com/ansys/pyaedt/actions/runs/14711189901/job/41283858673?pr=6078
https://github.com/ansys/actions/actions/runs/14713893172/job/41292794761?pr=791

Pinning the version fixes the issue until we figure out what is going on and make changes on ansys-sphinx-theme side. First two examples above now running fine with the fix:
https://github.com/ansys/pyaedt/actions/runs/14713307643/job/41290910358?pr=6078
https://github.com/ansys/pymapdl/actions/runs/14713554947/job/41291659271?pr=3875

FYI doc-build on this PR will still fail since we are referencing main before merging. So just override.
