### PR TITLE
fix: env var is missing after zizmore refactor

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -194,7 +194,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       if: ${{ inputs.checkout == 'true' }}
       with:
-        repository: ${{ env.DEPENDENCY_CHECK_REPOSITORY }}
+        repository: ${{ inputs.repo-full-name == '' && github.repository || inputs.repo-full-name }}
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
After #692 this doesn't work