### PR TITLE
refactor: remove deprecations and v8 refs

### DIFF
--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -131,22 +131,6 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier==${TOWNCRIER_VERSION} toml==${TOML_VERSION}
 
-    # TODO: remove this deprecation in ansys/actions@v9
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
-      with:
-        level: "ERROR"
-        message: >
-          Ansys Actions v8 will require bot username and email inputs in the
-          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
-          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
-          to the respective workflows and see
-          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
-          for more information.
-
-    # TODO: end
-
     - name: "Get first letter of conventional commit type"
       if: ${{ inputs.use-conventional-commits == 'true' }}
       env:
@@ -164,13 +148,13 @@ runs:
 
     - name: "Check pull-request title follows conventional commits style"
       if: ${{ (inputs.use-conventional-commits == 'true') && (env.FIRST_LETTER == 'lowercase') }}
-      uses: ansys/actions/check-pr-title@v8
+      uses: ansys/actions/check-pr-title@main
       with:
         token: ${{ inputs.token }}
 
     - name: "Check pull-request title follows conventional commits style with upper case"
       if: ${{ (inputs.use-conventional-commits == 'true') && (env.FIRST_LETTER == 'uppercase') }}
-      uses: ansys/actions/check-pr-title@v8
+      uses: ansys/actions/check-pr-title@main
       with:
         token: ${{ inputs.token }}
         use-upper-case: true

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -205,22 +205,6 @@ runs:
       run: |
         python -m pip install --upgrade pip towncrier=="${TOWNCRIER_VERSION}" toml=="${TOML_VERSION}"
 
-    # TODO: remove this deprecation in ansys/actions@v9
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
-      with:
-        level: "ERROR"
-        message: >
-          Ansys Actions v8 will require bot username and email inputs in the
-          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
-          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
-          to the respective workflows and see
-          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
-          for more information.
-
-    # TODO: end
-
     - name: "Get towncrier directory and project name"
       shell: python
       run: |

--- a/doc-deploy-dev/action.yml
+++ b/doc-deploy-dev/action.yml
@@ -132,24 +132,6 @@ runs:
   using: "composite"
   steps:
 
-    # TODO: remove this deprecation in ansys/actions@v9
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
-      with:
-        level: "ERROR"
-        message: >
-          Ansys Actions v8 will require bot username and email inputs in the
-          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
-          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
-          to the respective workflows and see
-          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
-          for more information.
-
-    # TODO: end
-
-    # ------------------------------------------------------------------------
-
     - uses: ansys/actions/_logging@main
       with:
         level: "INFO"

--- a/doc-deploy-stable/action.yml
+++ b/doc-deploy-stable/action.yml
@@ -155,24 +155,6 @@ runs:
   using: "composite"
   steps:
 
-    # TODO: remove this deprecation in ansys/actions@v9
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ (inputs.bot-user == '') || (inputs.bot-email == '') }}
-      with:
-        level: "ERROR"
-        message: >
-          Ansys Actions v8 will require bot username and email inputs in the
-          ``doc-changelog``, ``doc-deploy-changelog``, ``doc-deploy-dev`` and
-          ``doc-deploy-stable`` actions. Please add the bot-user and bot-email inputs
-          to the respective workflows and see
-          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
-          for more information.
-
-    # TODO: end
-
-    # ------------------------------------------------------------------------
-
     - uses: ansys/actions/_logging@main
       with:
         level: "INFO"

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -148,20 +148,6 @@ runs:
   using: "composite"
   steps:
 
-    # TODO: remove this deprecation in ansys/actions@v9
-
-    - uses: ansys/actions/_logging@main
-      if: ${{ inputs.token == '' }}
-      with:
-        level: "ERROR"
-        message: >
-          Ansys Actions v9 will require the token input in the ``release-github`` action.
-          Please add the token input to this action and see
-          https://actions.docs.ansys.com/version/dev/migrations/index.html#migration-guide
-          for more information.
-
-    # TODO: end
-
     # Only one of both can be true: generate_release_notes, changelog-release-notes
     - name: "Sanity check on release notes"
       uses: ansys/actions/_logging@main
@@ -295,7 +281,7 @@ runs:
       run: ls -R dist/
 
     - name: "Set up Python"
-      uses: ansys/actions/_setup-python@v8
+      uses: ansys/actions/_setup-python@main
       with:
         python-version: ${{ inputs.python-version }}
         use-cache: ${{ inputs.use-python-cache }}


### PR DESCRIPTION
Since v9 is out, we should remove the deprecation warnings that we planned to removed.
Also, there were some references to `v8` that are now using `main` instead.