### PR TITLE
feat: pr documentation deployment and cleanup

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ansys/actions/doc-changelog@main
+      - uses: ansys/actions/doc-changelog@fix/uv-in-actions-without-venv-creation
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           use-conventional-commits: true

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: ansys/actions/doc-changelog@fix/uv-in-actions-without-venv-creation
+      - uses: ansys/actions/doc-changelog@main
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           use-conventional-commits: true

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -68,8 +68,22 @@ runs:
       run: |
         echo -e "User-agent: *\n" >> robots.txt
 
+    # This is needed so that pull/ is not removed from the robots.txt file
+    # if it already exists when `doc-deploy-dev` or `doc-deploy-stable` is run.
+    - name: "Check for the presence of pull/ in robots.txt"
+      id: check-robots-for-pull-directory
+      shell: bash
+      run: |
+        if grep -q "Disallow: /pull/" robots.txt; then
+          echo "EXISTS_PULL_DIRECTORY=true" >> ${GITHUB_OUTPUT}
+        else
+          echo "EXISTS_PULL_DIRECTORY=false" >> ${GITHUB_OUTPUT}
+        fi
+
     - name: "Iterate over all versions except the "
       shell: bash
+      env:
+        EXISTS_PULL_DIRECTORY: ${{ steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY }}
       run: |
         for version in $(ls version |
                     grep -E "^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\..*)?$" | \
@@ -78,9 +92,13 @@ runs:
                     tail -n +2); do
             echo "Disallow: /version/${version}" >> robots.txt
         done
+        if [[ "${EXISTS_PULL_DIRECTORY}" == "true" ]]; then
+          echo "Disallow: /pull/" >> robots.txt
+        fi
 
+    # This is triggered the first time a project uses `doc-deploy-pr`
     - name: "Disallow the pull request documentation directory"
-      if: ${{ inputs.disallow-pr == 'true' }}
+      if: ${{ inputs.disallow-pr == 'true' && steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY == 'false' }}
       shell: bash
       run: |
         echo "Disallow: /pull/" >> robots.txt

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: true
     type: string
 
-  disallow-pr:
+  disallow-pull:
     description: |
       Disallow the pull request documentation.
     required: false
@@ -98,7 +98,7 @@ runs:
 
     # This is triggered the first time a project uses `doc-deploy-pr`
     - name: "Disallow the pull request documentation directory"
-      if: ${{ inputs.disallow-pr == 'true' && steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY == 'false' }}
+      if: ${{ inputs.disallow-pull == 'true' && steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY == 'false' }}
       shell: bash
       run: |
         echo "Disallow: /pull/" >> robots.txt

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -39,6 +39,13 @@ inputs:
     required: true
     type: string
 
+  disallow-pr:
+    description: |
+      Disallow the pull request documentation.
+    required: false
+    default: false
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -71,6 +78,11 @@ runs:
                     tail -n +2); do
             echo "Disallow: /version/${version}" >> robots.txt
         done
+
+    - name: "Disallow the pull request documentatio directory"
+      if: ${{ inputs.disallow-pr == 'true' }}
+      shell: bash
+      run: |
         echo "Disallow: /pr/" >> robots.txt
 
     - name: "Include the location of the sitemap.xml file"

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -79,11 +79,11 @@ runs:
             echo "Disallow: /version/${version}" >> robots.txt
         done
 
-    - name: "Disallow the pull request documentatio directory"
+    - name: "Disallow the pull request documentation directory"
       if: ${{ inputs.disallow-pr == 'true' }}
       shell: bash
       run: |
-        echo "Disallow: /pr/" >> robots.txt
+        echo "Disallow: /pull/" >> robots.txt
 
     - name: "Include the location of the sitemap.xml file"
       shell: bash

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -71,6 +71,7 @@ runs:
                     tail -n +2); do
             echo "Disallow: /version/${version}" >> robots.txt
         done
+        echo "Disallow: /pr/" >> robots.txt
 
     - name: "Include the location of the sitemap.xml file"
       shell: bash

--- a/_doc-gen-robots/action.yml
+++ b/_doc-gen-robots/action.yml
@@ -39,13 +39,6 @@ inputs:
     required: true
     type: string
 
-  disallow-pull:
-    description: |
-      Disallow the pull request documentation.
-    required: false
-    default: false
-    type: boolean
-
 runs:
   using: "composite"
   steps:
@@ -68,22 +61,8 @@ runs:
       run: |
         echo -e "User-agent: *\n" >> robots.txt
 
-    # This is needed so that pull/ is not removed from the robots.txt file
-    # if it already exists when `doc-deploy-dev` or `doc-deploy-stable` is run.
-    - name: "Check for the presence of pull/ in robots.txt"
-      id: check-robots-for-pull-directory
-      shell: bash
-      run: |
-        if grep -q "Disallow: /pull/" robots.txt; then
-          echo "EXISTS_PULL_DIRECTORY=true" >> ${GITHUB_OUTPUT}
-        else
-          echo "EXISTS_PULL_DIRECTORY=false" >> ${GITHUB_OUTPUT}
-        fi
-
     - name: "Iterate over all versions except the "
       shell: bash
-      env:
-        EXISTS_PULL_DIRECTORY: ${{ steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY }}
       run: |
         for version in $(ls version |
                     grep -E "^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\..*)?$" | \
@@ -92,15 +71,6 @@ runs:
                     tail -n +2); do
             echo "Disallow: /version/${version}" >> robots.txt
         done
-        if [[ "${EXISTS_PULL_DIRECTORY}" == "true" ]]; then
-          echo "Disallow: /pull/" >> robots.txt
-        fi
-
-    # This is triggered the first time a project uses `doc-deploy-pr`
-    - name: "Disallow the pull request documentation directory"
-      if: ${{ inputs.disallow-pull == 'true' && steps.check-robots-for-pull-directory.outputs.EXISTS_PULL_DIRECTORY == 'false' }}
-      shell: bash
-      run: |
         echo "Disallow: /pull/" >> robots.txt
 
     - name: "Include the location of the sitemap.xml file"

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -206,7 +206,7 @@ runs:
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body: |
+        body: >
           The documentation for this pull request has been deleted and will no longer be available at
           [https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }})
           shortly.

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -44,7 +44,7 @@ inputs:
       is enough. For workflows deploying to other repositories, `generate and
       use a token with writing access
       <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
-      to that repository.
+      to that repository. ``contents: write`` and ``pull-requests: write`` are minimum permissions required for this token.
     required: true
     type: string
 

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -129,15 +129,15 @@ runs:
         BOT_EMAIL: ${{ inputs.bot-email }}
         BRANCH: ${{ inputs.branch }}
       run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
-        # Check the ${{ inputs.branch }} branch exists on remote
+        # Check the ${{ env.BRANCH }} branch exists on remote
         branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
 
-        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
+        # If the ${{ env.BRANCH }} doesn't exist, then print error message and exit 1
         if [ -z "$branch_exists" ]; then
           echo "The $BRANCH branch does not exist. Failing the workflow."
           exit 1
         else
-          # Fetch and switch to ${{ inputs.branch }}
+          # Fetch and switch to ${{ env.BRANCH }}
           git fetch origin "${BRANCH}:${BRANCH}"
           git switch "$BRANCH"
         fi
@@ -207,6 +207,5 @@ runs:
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: >
-          The documentation for this pull request has been deleted and will no longer be available at
-          [https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }})
-          shortly.
+          This PR has been closed. Documentation for this pull request will shortly be removed from its
+          [former deployment address](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}).

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -32,10 +32,10 @@ inputs:
 
   # Required inputs
   cname:
-  description: |
-    The canonical name (CNAME) containing the documentation.
-  required: true
-  type: string
+    description: |
+      The canonical name (CNAME) containing the documentation.
+    required: true
+    type: string
 
   token:
     description: |

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -1,0 +1,197 @@
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: |
+  Remove the documentation for a closed pull-request.
+
+description: |
+  This action removes the html documentation when the corresponding pull request is closed.
+  By default, the ``gh-pages`` branch of the current repository is assumed, and the documentation
+  is removed from ``https://<cname>/pull/<pr-number>/``.
+
+inputs:
+
+  # Required inputs
+
+  token:
+    description: |
+      Required password, key or token with the correct credentials for deploying the
+      documentation. If deploying to the current repository, the ``secrets.GITHUB_TOKEN`` token is
+      is enough. For workflows deploying to other repositories, `generate and
+      use a token with writing access
+      <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+      to that repository.
+    required: true
+    type: string
+
+  bot-user:
+    description: |
+      Use the PYANSYS_CI_BOT_USERNAME as the user for a git commit & push.
+    required: true
+    type: string
+
+  bot-email:
+    description: |
+      Use the PYANSYS_CI_BOT_EMAIL as the email for a git commit & push.
+    required: true
+    type: string
+
+  # Optional inputs
+
+  repository:
+    description: |
+      Repository name in the form of ``username/repository`` to be used for
+      deploying the documentation. The current repository is assumed by default.
+    required: false
+    default: 'current'
+    type: string
+
+  branch:
+    description: |
+      Branch name for deploying the documentation. The ``gh-pages`` branch is
+      used by default.
+    required: false
+    default: 'gh-pages'
+    type: string
+
+  commit-message:
+    description: |
+      Commit message used when deploying the documentation.
+    required: false
+    default: 'DOC: remove pull request documentation'
+    type: string
+
+  force-orphan:
+    description: |
+      Whether to force the deployment branch to be orphan or not. Default value
+      is ``true``.
+    required: false
+    default: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Checkout the repository branch for removing the documentation. If this
+          step fails, then it means that the provided token is not valid.
+
+    - name: "Get the name of the repository"
+      shell: bash
+      id: get-repository-name
+      env:
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+      run: |
+        if [[ "$INPUT_REPOSITORY" == "current" ]]; then
+          echo "REPOSITORY=${{ github.repository }}" >> $GITHUB_OUTPUT
+        else
+          echo "REPOSITORY=${INPUT_REPOSITORY}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: "Checkout ${{ steps.get-repository-name.outputs.REPOSITORY }} repository"
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: ${{ steps.get-repository-name.outputs.REPOSITORY }}
+        token: ${{ inputs.token }}
+
+    - name: "Ensure that the desired branch exists"
+      shell: bash
+      env:
+        BOT_USER: ${{ inputs.bot-user }}
+        BOT_EMAIL: ${{ inputs.bot-email }}
+        BRANCH: ${{ inputs.branch }}
+      run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
+        # Check the ${{ inputs.branch }} branch exists on remote
+        branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
+
+        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
+        if [ -z "$branch_exists" ]; then
+          echo "The $BRANCH branch does not exist. Failing the workflow."
+          exit 1
+        else
+          # Fetch and switch to ${{ inputs.branch }}
+          git fetch origin "${BRANCH}:${BRANCH}"
+          git switch "$BRANCH"
+        fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Clean the desired PR documentation from the pull/ directory
+
+    - name: "Delete the documentation directory for the PR"
+      id: delete-pr-directory
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        # This conditional helps when a PR is closed before actual deployment.
+        if [[ -d pull/${PR_NUMBER} ]]; then
+          rm -rf pull/${PR_NUMBER}
+          echo "PR_DIRECTORY_DELETED=true" >> ${{ GITHUB_OUTPUT }}
+          echo "Documentation for pull-request ${PR_NUMBER} removed."
+        else
+          echo "Documentation for pull-request ${PR_NUMBER} does not exist."
+          echo "PR_DIRECTORY_DELETED=false" >> ${{ GITHUB_OUTPUT }}
+        fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      if: steps.delete-pr-directory.outputs.PR_DIRECTORY_DELETED == true
+      with:
+        level: "INFO"
+        message: >
+          For deploying the documentation, a GitHub token or a deployment token
+          is required. The GitHub token is used when deploying to the current
+          repository while the deployment token is used to deploy to an external
+          repository.
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
+      if: inputs.repository == 'current' && steps.delete-pr-directory.outputs.PR_DIRECTORY_DELETED == 'true'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        github_token: ${{ inputs.token }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
+      if: inputs.repository != 'current' && steps.delete-pr-directory.outputs.PR_DIRECTORY_DELETED == 'true'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        personal_token: ${{ inputs.token }}
+        external_repository: ${{ inputs.repository }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -154,11 +154,11 @@ runs:
         # This conditional helps when a PR is closed before actual deployment.
         if [[ -d pull/${PR_NUMBER} ]]; then
           rm -rf pull/${PR_NUMBER}
-          echo "PR_DIRECTORY_DELETED=true" >> ${{ GITHUB_OUTPUT }}
+          echo "PR_DIRECTORY_DELETED=true" >> ${GITHUB_OUTPUT}
           echo "Documentation for pull-request ${PR_NUMBER} removed."
         else
           echo "Documentation for pull-request ${PR_NUMBER} does not exist."
-          echo "PR_DIRECTORY_DELETED=false" >> ${{ GITHUB_OUTPUT }}
+          echo "PR_DIRECTORY_DELETED=false" >> ${GITHUB_OUTPUT}
         fi
 
     # ------------------------------------------------------------------------

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -31,6 +31,11 @@ description: |
 inputs:
 
   # Required inputs
+  cname:
+  description: |
+    The canonical name (CNAME) containing the documentation.
+  required: true
+  type: string
 
   token:
     description: |
@@ -195,3 +200,13 @@ runs:
         commit_message: ${{ inputs.commit-message }}
         keep_files: true
         force_orphan: ${{ inputs.force-orphan }}
+
+    - name: "Make a PR comment when PR documentation is deleted"
+      if: steps.delete-pr-directory.outputs.PR_DIRECTORY_DELETED == 'true'
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          The documentation for this pull request has been deleted and will no longer be available at
+          [https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }})
+          shortly.

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -208,5 +208,5 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           The documentation for this pull request has been deleted and will no longer be available at
-          [https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }})
+          [https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }})
           shortly.

--- a/_pr-doc-clean/action.yml
+++ b/_pr-doc-clean/action.yml
@@ -40,9 +40,9 @@ inputs:
   token:
     description: |
       Required password, key or token with the correct credentials for deploying the
-      documentation. If deploying to the current repository, the ``secrets.GITHUB_TOKEN`` token is
+      documentation. If deploying to the current repository, the ``secrets.GITHUB_TOKEN`` token
       is enough. For workflows deploying to other repositories, `generate and
-      use a token with writing access
+      use a token with write access
       <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
       to that repository. ``contents: write`` and ``pull-requests: write`` are minimum permissions required for this token.
     required: true

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -149,10 +149,10 @@ runs:
         BOT_EMAIL: ${{ inputs.bot-email }}
         BRANCH: ${{ inputs.branch }}
       run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
-        # Check the ${{ inputs.branch }} branch exists on remote
+        # Check the ${{ env.BRANCH }} branch exists on remote
         branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
 
-        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
+        # If the ${{ env.BRANCH }} doesn't exist, then print error message and exit 1
         if [ -z "$branch_exists" ]; then
           echo "The $BRANCH branch does not exist. Creating $BRANCH."
 
@@ -169,11 +169,11 @@ runs:
           git config user.name "$BOT_USER"
           git config user.email "$BOT_EMAIL"
 
-          # Commit ${{ inputs.branch }} & push to origin
+          # Commit ${{ env.BRANCH }} & push to origin
           git commit --allow-empty -m "Create $BRANCH branch"
           git push -u origin "$BRANCH"
         else
-          # Fetch and switch to ${{ inputs.branch }}
+          # Fetch and switch to ${{ env.BRANCH }}
           git fetch origin "${BRANCH}:${BRANCH}"
           git switch "$BRANCH"
         fi

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -32,6 +32,12 @@ description: |
 inputs:
 
   # Required inputs
+  
+  cname:
+    description: |
+      The canonical name (CNAME) containing the documentation.
+    required: true
+    type: string
 
   token:
     description: |
@@ -238,6 +244,19 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         ls -R pull/${PR_NUMBER}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Generate the "robots.txt" file for guiding web crawlers (spiders)
+
+    - name: "Generate 'robots.txt' file"
+      uses: ansys/actions/_doc-gen-robots@main
+      with:
+        cname: ${{ inputs.cname }}
 
     # ------------------------------------------------------------------------
 

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -303,5 +303,5 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           The documentation for this pull request will be available at
-          [https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}).
+          [https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}).
           Please allow some time for the documentation to be deployed.

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -1,0 +1,274 @@
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: |
+  Deploy the documentation for a pull-request.
+
+description: |
+  This action deploys the HTML documentation artifact corresponding to the
+  pull request event that triggers it. By default, the ``gh-pages`` branch of the
+  current repository is assumed, and the documentation will be available at
+  ``https://<cname>/pull/<pr-number>/``
+
+inputs:
+
+  # Required inputs
+
+  token:
+    description: |
+      Required password, key or token with the correct credentials for deploying the
+      documentation. If deploying to the current repository, the ``secrets.GITHUB_TOKEN`` token is
+      is enough. For workflows deploying to other repositories, `generate and
+      use a token with writing access
+      <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+      to that repository.
+    required: true
+    type: string
+
+  bot-user:
+    description: |
+      Use the PYANSYS_CI_BOT_USERNAME as the user for a git commit & push.
+    required: true
+    type: string
+
+  bot-email:
+    description: |
+      Use the PYANSYS_CI_BOT_EMAIL as the email for a git commit & push.
+    required: true
+    type: string
+
+  # Optional inputs
+
+  doc-artifact-name:
+    description: |
+        Name of the HTML documentation artifact. This artifact is expected to
+        contain all the HTML and static files. If it contains a compressed file,
+        make sure you enable the ``decompress-artifact`` option.
+    required: false
+    default: 'documentation-html'
+    type: string
+
+  decompress-artifact:
+    description: |
+      Whether to decompress the ``doc-artifact-name`` file using `ouch
+      <https://github.com/ouch-org/ouch>`_ as decompression tool. Default value
+      is ``false``.
+    required: false
+    default: false
+    type: string
+
+  repository:
+    description: |
+      Repository name in the form of ``username/repository`` to be used for
+      deploying the documentation. The current repository is assumed by default.
+    required: false
+    default: 'current'
+    type: string
+
+  branch:
+    description: |
+      Branch name for deploying the documentation. The ``gh-pages`` branch is
+      used by default.
+    required: false
+    default: 'gh-pages'
+    type: string
+
+  commit-message:
+    description: |
+      Commit message used when deploying the documentation.
+    required: false
+    default: 'DOC: update pull request documentation'
+    type: string
+
+  force-orphan:
+    description: |
+      Whether to force the deployment branch to be orphan or not. Default value
+      is ``true``.
+    required: false
+    default: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Checkout the repository branch for deploying the documentation. If this
+          step fails, then it means that the provided token is not valid.
+
+    - name: "Get the name of the repository"
+      shell: bash
+      id: get-repository-name
+      env:
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+      run: |
+        if [[ "$INPUT_REPOSITORY" == "current" ]]; then
+          echo "REPOSITORY=${{ github.repository }}" >> $GITHUB_OUTPUT
+        else
+          echo "REPOSITORY=${INPUT_REPOSITORY}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: "Checkout ${{ steps.get-repository-name.outputs.REPOSITORY }} repository"
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: ${{ steps.get-repository-name.outputs.REPOSITORY }}
+        token: ${{ inputs.token }}
+
+    - name: "Ensure that the desired branch exists"
+      shell: bash
+      env:
+        BOT_USER: ${{ inputs.bot-user }}
+        BOT_EMAIL: ${{ inputs.bot-email }}
+        BRANCH: ${{ inputs.branch }}
+      run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
+        # Check the ${{ inputs.branch }} branch exists on remote
+        branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
+
+        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
+        if [ -z "$branch_exists" ]; then
+          echo "The $BRANCH branch does not exist. Creating $BRANCH."
+
+          # Create orphan branch
+          git checkout --orphan "$BRANCH"
+
+          # Unstage files to be committed
+          git rm --cached -r .
+
+          # Remove untracked files
+          git clean -fd
+
+          # Configure git username & email
+          git config user.name "$BOT_USER"
+          git config user.email "$BOT_EMAIL"
+
+          # Commit ${{ inputs.branch }} & push to origin
+          git commit --allow-empty -m "Create $BRANCH branch"
+          git push -u origin "$BRANCH"
+        else
+          # Fetch and switch to ${{ inputs.branch }}
+          git fetch origin "${BRANCH}:${BRANCH}"
+          git switch "$BRANCH"
+        fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Download the pr documentation artifact in a folder that has the same
+          name as the version number. Decompress artifact if required. Finally,
+          display the structure of the directory to verify that it has the right
+          layout.
+
+    - name: "Ensure existence of the root PR documentation directory"
+      shell: bash
+      run: |
+        if [[ -d pull/ ]]; then
+          echo "PR documentation folder already exists."
+        else
+          mkdir pull/
+          echo "PR documentation folder created."
+        fi
+
+    - name: "Ensure existence of the clean sub-directory corresponding to the current PR"
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if [[ -d pull/${PR_NUMBER} ]]; then
+          echo "Directory corresponding to this PR's documentation detected, cleaning ..."
+          rm -rf pull/${PR_NUMBER} && mkdir pull/${PR_NUMBER}
+        else
+          mkdir pull/${PR_NUMBER}
+          echo "Directory for deploying documentation of the PR created."
+        fi
+
+    - name: "Download the pr documentation artifact"
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      with:
+        name: ${{ inputs.doc-artifact-name }}
+        path: pull/${{ github.event.pull_request.number }}
+
+    - name: "Update apt-get"
+      shell: bash
+      run: |
+        sudo apt-get update
+
+    - name: "Decompress artifact content"
+      shell: bash
+      if: inputs.decompress-artifact == 'true'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        sudo apt-get install -y cargo && cargo install ouch
+        export PATH="$HOME/.cargo/bin/:$PATH"
+        ouch --version
+        cd pull/${PR_NUMBER} && compressed_artifact=$(ls .)
+        ouch decompress $compressed_artifact
+        decompressed_artifact=$(ls -I "*${compressed_artifact##*.}")
+        mv $decompressed_artifact/* .
+        rm -rf $compressed_artifact $decompressed_artifact
+
+    - name: "Display structure of pull/${{ github.event.pull_request.number }}"
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        ls -R pull/${PR_NUMBER}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          For deploying the documentation, a GitHub token or a deployment token
+          is required. The GitHub token is used when deploying to the current
+          repository while the deployment token is used to deploy to an external
+          repository.
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
+      if: inputs.repository == 'current'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        github_token: ${{ inputs.token }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
+      if: inputs.repository != 'current'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        personal_token: ${{ inputs.token }}
+        external_repository: ${{ inputs.repository }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -254,7 +254,7 @@ runs:
           Generate the "robots.txt" file for guiding web crawlers (spiders)
 
     - name: "Generate 'robots.txt' file"
-      uses: ansys/actions/_doc-gen-robots@main
+      uses: ansys/actions/_doc-gen-robots@feat/pr-documentation-deployment-and-cleanup
       with:
         cname: ${{ inputs.cname }}
 

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -27,7 +27,7 @@ description: |
   This action deploys the HTML documentation artifact corresponding to the
   pull request event that triggers it. By default, the ``gh-pages`` branch of the
   current repository is assumed, and the documentation will be available at
-  ``https://<cname>/pull/<pr-number>/``
+  ``https://<cname>/pull/<pr-number>/``.
 
 inputs:
 
@@ -46,7 +46,7 @@ inputs:
       is enough. For workflows deploying to other repositories, `generate and
       use a token with writing access
       <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
-      to that repository.
+      to that repository. ``contents: write`` and ``pull-requests: write`` are minimum permissions required for this token.
     required: true
     type: string
 

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -32,7 +32,7 @@ description: |
 inputs:
 
   # Required inputs
-  
+
   cname:
     description: |
       The canonical name (CNAME) containing the documentation.

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -301,7 +301,7 @@ runs:
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body: |
+        body: >
           The documentation for this pull request will be available at
           [https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://${{ inputs.cname }}/pull/${{ github.event.pull_request.number }}).
           Please allow some time for the documentation to be deployed.

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -257,6 +257,7 @@ runs:
       uses: ansys/actions/_doc-gen-robots@feat/pr-documentation-deployment-and-cleanup
       with:
         cname: ${{ inputs.cname }}
+        disallow-pr: true
 
     # ------------------------------------------------------------------------
 

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -200,6 +200,7 @@ runs:
         fi
 
     - name: "Ensure existence of the clean sub-directory corresponding to the current PR"
+      id: create-pr-directory
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -210,6 +211,8 @@ runs:
         else
           mkdir pull/${PR_NUMBER}
           echo "Directory for deploying documentation of the PR created."
+          # This means this is the first time the PR documentation is being deployed
+          echo "FIRST_TIME_DEPLOYMENT=true" >> ${GITHUB_OUTPUT}
         fi
 
     - name: "Download the pr documentation artifact"
@@ -292,3 +295,13 @@ runs:
         commit_message: ${{ inputs.commit-message }}
         keep_files: true
         force_orphan: ${{ inputs.force-orphan }}
+
+    - name: "Make a PR comment the first time a PR documentation is deployed"
+      if: steps.create-pr-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true'
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          The documentation for this pull request will be available at
+          [https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}](https://{{ inputs.cname }}/pull/${{ github.event.pull_request.number }}).
+          Please allow some time for the documentation to be deployed.

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -260,7 +260,6 @@ runs:
       uses: ansys/actions/_doc-gen-robots@feat/pr-documentation-deployment-and-cleanup
       with:
         cname: ${{ inputs.cname }}
-        disallow-pull: true
 
     # ------------------------------------------------------------------------
 

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -260,7 +260,7 @@ runs:
       uses: ansys/actions/_doc-gen-robots@feat/pr-documentation-deployment-and-cleanup
       with:
         cname: ${{ inputs.cname }}
-        disallow-pr: true
+        disallow-pull: true
 
     # ------------------------------------------------------------------------
 

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -1,0 +1,273 @@
+# Copyright (C) 2022 - 2025 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: |
+  Doc deploy pr action
+
+description: |
+  This action deploys the HTML documentation artifact corresponding to the
+  pull request that triggers it. By default, the ``gh-pages`` branch of the
+  current repository is assumed, and the documentation will be available at
+  ``https://<cname>/pr/<pr-number>/``
+
+inputs:
+
+  # Required inputs
+
+  token:
+    description: |
+      Required password, key or token with the correct credentials for deploying the
+      documentation. If deploying to the current repository, the ``secrets.GITHUB_TOKEN`` token is
+      is enough. For workflows deploying to other repositories, `generate and
+      use a token with writing access
+      <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
+      to that repository.
+    required: true
+    type: string
+
+  bot-user:
+    description: |
+      Use the PYANSYS_CI_BOT_USERNAME as the user for a git commit & push.
+    required: true
+    type: string
+
+  bot-email:
+    description: |
+      Use the PYANSYS_CI_BOT_EMAIL as the email for a git commit & push.
+    required: true
+    type: string
+
+  # Optional inputs
+
+  doc-artifact-name:
+    description: |
+        Name of the HTML documentation artifact. This artifact is expected to
+        contain all the HTML and static files. If it contains a compressed file,
+        make sure you enable the ``decompress-artifact`` option.
+    required: false
+    default: 'documentation-html'
+    type: string
+
+  decompress-artifact:
+    description: |
+      Whether to decompress the ``doc-artifact-name`` file using `ouch
+      <https://github.com/ouch-org/ouch>`_ as decompression tool. Default value
+      is ``false``.
+    required: false
+    default: false
+    type: string
+
+  repository:
+    description: |
+      Repository name in the form of ``username/repository`` to be used for
+      deploying the documentation. The current repository is assumed by default.
+    required: false
+    default: 'current'
+    type: string
+
+  branch:
+    description: |
+      Branch name for deploying the documentation. The ``gh-pages`` branch is
+      used by default.
+    required: false
+    default: 'gh-pages'
+    type: string
+
+  commit-message:
+    description: |
+      Commit message used when deploying the documentation.
+    required: false
+    default: 'DOC: update pull request documentation'
+    type: string
+
+  force-orphan:
+    description: |
+      Whether to force the deployment branch to be orphan or not. Default value
+      is ``true``.
+    required: false
+    default: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Checkout the repository branch for deploying the documentation. If this
+          step fails, then it means that the provided token is not valid.
+
+    - name: "Get the name of the repository"
+      shell: bash
+      id: get-repository-name
+      env:
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+      run: |
+        if [[ "$INPUT_REPOSITORY" == "current" ]]; then
+          echo "REPOSITORY=${{ github.repository }}" >> $GITHUB_OUTPUT
+        else
+          echo "REPOSITORY=${INPUT_REPOSITORY}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: "Checkout ${{ steps.get-repository-name.outputs.REPOSITORY }} repository"
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: ${{ steps.get-repository-name.outputs.REPOSITORY }}
+        token: ${{ inputs.token }}
+
+    - name: "Ensure that the desired branch exists"
+      shell: bash
+      env:
+        BOT_USER: ${{ inputs.bot-user }}
+        BOT_EMAIL: ${{ inputs.bot-email }}
+        BRANCH: ${{ inputs.branch }}
+      run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
+        # Check the ${{ inputs.branch }} branch exists on remote
+        branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
+
+        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
+        if [ -z "$branch_exists" ]; then
+          echo "The $BRANCH branch does not exist. Creating $BRANCH."
+
+          # Create orphan branch
+          git checkout --orphan "$BRANCH"
+
+          # Unstage files to be committed
+          git rm --cached -r .
+
+          # Remove untracked files
+          git clean -fd
+
+          # Configure git username & email
+          git config user.name "$BOT_USER"
+          git config user.email "$BOT_EMAIL"
+
+          # Commit ${{ inputs.branch }} & push to origin
+          git commit --allow-empty -m "Create $BRANCH branch"
+          git push -u origin "$BRANCH"
+        else
+          # Fetch and switch to ${{ inputs.branch }}
+          git fetch origin "${BRANCH}:${BRANCH}"
+          git switch "$BRANCH"
+        fi
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          Download the pr documentation artifact in a folder that has the same
+          name as the version number. Decompress artifact if required. Finally,
+          display the structure of the directory to verify that it has the right
+          layout.
+
+    - name: "Ensure existence of the root PR documentation directory"
+      shell: bash
+      run: |
+        if [[ -d pr/ ]]; then
+          echo "PR documentation folder already exists."
+        else
+          mkdir pr/
+          echo "PR documentation folder created."
+        fi
+
+    - name: "Ensure existence of the clean sub-directory corresponding to the current PR"
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if [[ -d pr/${PR_NUMBER} ]]; then
+          echo "Directory corresponding to this PR's documentation detected, cleaning ..."
+          rm -rf pr/${PR_NUMBER} && mkdir pr/${PR_NUMBER}
+        else
+          mkdir pr/${PR_NUMBER}
+          echo "Directory for deploying documentation of the PR created."
+
+    - name: "Download the pr documentation artifact"
+      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+      with:
+        name: ${{ inputs.doc-artifact-name }}
+        path: pr/${{ github.event.pull_request.number }}
+
+    - name: "Update apt-get"
+      shell: bash
+      run: |
+        sudo apt-get update
+
+    - name: "Decompress artifact content"
+      shell: bash
+      if: inputs.decompress-artifact == 'true'
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        sudo apt-get install -y cargo && cargo install ouch
+        export PATH="$HOME/.cargo/bin/:$PATH"
+        ouch --version
+        cd PR/${PR_NUMBER} && compressed_artifact=$(ls .)
+        ouch decompress $compressed_artifact
+        decompressed_artifact=$(ls -I "*${compressed_artifact##*.}")
+        mv $decompressed_artifact/* .
+        rm -rf $compressed_artifact $decompressed_artifact
+
+    - name: "Display structure of pr/${{ github.event.pull_request.number }}"
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        ls -R pr/${PR_NUMBER}
+
+    # ------------------------------------------------------------------------
+
+    - uses: ansys/actions/_logging@main
+      with:
+        level: "INFO"
+        message: >
+          For deploying the documentation, a GitHub token or a deployment token
+          is required. The GitHub token is used when deploying to the current
+          repository while the deployment token is used to deploy to an external
+          repository.
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
+      if: inputs.repository == 'current'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        github_token: ${{ inputs.token }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}
+
+    - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
+      if: inputs.repository != 'current'
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      with:
+        publish_dir: .
+        publish_branch: ${{ inputs.branch }}
+        personal_token: ${{ inputs.token }}
+        external_repository: ${{ inputs.repository }}
+        commit_message: ${{ inputs.commit-message }}
+        keep_files: true
+        force_orphan: ${{ inputs.force-orphan }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -47,7 +47,7 @@ inputs:
       is enough. For workflows deploying to other repositories, `generate and
       use a token with writing access
       <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token>`_
-      to that repository.
+      to that repository. ``contents: write`` and ``pull-requests: write`` are minimum permissions required for this token.
     required: true
     type: string
 

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -204,6 +204,7 @@ runs:
         else
           mkdir pr/${PR_NUMBER}
           echo "Directory for deploying documentation of the PR created."
+        fi
 
     - name: "Download the pr documentation artifact"
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -27,7 +27,7 @@ description: |
   This action deploys the HTML documentation artifact corresponding to the
   pull request that triggers it. By default, the ``gh-pages`` branch of the
   current repository is assumed, and the documentation will be available at
-  ``https://<cname>/pr/<pr-number>/``
+  ``https://<cname>/pull/<pr-number>/``
 
 inputs:
 
@@ -186,10 +186,10 @@ runs:
     - name: "Ensure existence of the root PR documentation directory"
       shell: bash
       run: |
-        if [[ -d pr/ ]]; then
+        if [[ -d pull/ ]]; then
           echo "PR documentation folder already exists."
         else
-          mkdir pr/
+          mkdir pull/
           echo "PR documentation folder created."
         fi
 
@@ -198,11 +198,11 @@ runs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        if [[ -d pr/${PR_NUMBER} ]]; then
+        if [[ -d pull/${PR_NUMBER} ]]; then
           echo "Directory corresponding to this PR's documentation detected, cleaning ..."
-          rm -rf pr/${PR_NUMBER} && mkdir pr/${PR_NUMBER}
+          rm -rf pull/${PR_NUMBER} && mkdir pull/${PR_NUMBER}
         else
-          mkdir pr/${PR_NUMBER}
+          mkdir pull/${PR_NUMBER}
           echo "Directory for deploying documentation of the PR created."
         fi
 
@@ -210,7 +210,7 @@ runs:
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.doc-artifact-name }}
-        path: pr/${{ github.event.pull_request.number }}
+        path: pull/${{ github.event.pull_request.number }}
 
     - name: "Update apt-get"
       shell: bash
@@ -226,18 +226,18 @@ runs:
         sudo apt-get install -y cargo && cargo install ouch
         export PATH="$HOME/.cargo/bin/:$PATH"
         ouch --version
-        cd PR/${PR_NUMBER} && compressed_artifact=$(ls .)
+        cd pull/${PR_NUMBER} && compressed_artifact=$(ls .)
         ouch decompress $compressed_artifact
         decompressed_artifact=$(ls -I "*${compressed_artifact##*.}")
         mv $decompressed_artifact/* .
         rm -rf $compressed_artifact $decompressed_artifact
 
-    - name: "Display structure of pr/${{ github.event.pull_request.number }}"
+    - name: "Display structure of pull/${{ github.event.pull_request.number }}"
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        ls -R pr/${PR_NUMBER}
+        ls -R pull/${PR_NUMBER}
 
     # ------------------------------------------------------------------------
 

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -33,6 +33,12 @@ inputs:
 
   # Required inputs
 
+  cname:
+    description: |
+      The canonical name (CNAME) containing the documentation.
+    required: true
+    type: string
+
   token:
     description: |
       Required password, key or token with the correct credentials for deploying the
@@ -114,6 +120,7 @@ runs:
     - uses: ansys/actions/_pr-doc-deployment@feat/pr-documentation-deployment-and-cleanup
       if: github.event.pull_request.state == 'open'
       with:
+        cname: ${{ inputs.cname }}
         token: ${{ inputs.token }}
         bot-user: ${{ inputs.bot-user }}
         bot-email: ${{ inputs.bot-email }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -25,9 +25,10 @@ name: |
 
 description: |
   This action deploys the HTML documentation artifact corresponding to the
-  pull request event that triggers it. By default, the ``gh-pages`` branch of the
+  pull request that triggers it. By default, the ``gh-pages`` branch of the
   current repository is assumed, and the documentation will be available at
-  ``https://<cname>/pull/<pr-number>/``
+  ``https://<cname>/pull/<pr-number>/``. The action also removes the deployed
+  PR documentation once the pull request is closed.
 
 inputs:
 

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -134,6 +134,7 @@ runs:
     - uses: ansys/actions/_pr-doc-clean@feat/pr-documentation-deployment-and-cleanup
       if: github.event.pull_request.state == 'closed'
       with:
+        cname: ${{ inputs.cname }}
         token: ${{ inputs.token }}
         bot-user: ${{ inputs.bot-user }}
         bot-email: ${{ inputs.bot-email }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -25,7 +25,7 @@ name: |
 
 description: |
   This action deploys the HTML documentation artifact corresponding to the
-  pull request that triggers it. By default, the ``gh-pages`` branch of the
+  pull request event that triggers it. By default, the ``gh-pages`` branch of the
   current repository is assumed, and the documentation will be available at
   ``https://<cname>/pull/<pr-number>/``
 
@@ -111,164 +111,26 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_pr-doc-deployment@feat/pr-documentation-deployment-and-cleanup
+      if: github.event.pull_request.state == 'open'
       with:
-        level: "INFO"
-        message: >
-          Checkout the repository branch for deploying the documentation. If this
-          step fails, then it means that the provided token is not valid.
-
-    - name: "Get the name of the repository"
-      shell: bash
-      id: get-repository-name
-      env:
-        INPUT_REPOSITORY: ${{ inputs.repository }}
-      run: |
-        if [[ "$INPUT_REPOSITORY" == "current" ]]; then
-          echo "REPOSITORY=${{ github.repository }}" >> $GITHUB_OUTPUT
-        else
-          echo "REPOSITORY=${INPUT_REPOSITORY}" >> $GITHUB_OUTPUT
-        fi
-
-    - name: "Checkout ${{ steps.get-repository-name.outputs.REPOSITORY }} repository"
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: ${{ steps.get-repository-name.outputs.REPOSITORY }}
         token: ${{ inputs.token }}
+        bot-user: ${{ inputs.bot-user }}
+        bot-email: ${{ inputs.bot-email }}
+        doc-artifact-name: ${{ inputs.doc-artifact-name }}
+        decompress-artifact: ${{ inputs.decompress-artifact }}
+        repository: ${{ inputs.repository }}
+        branch: ${{ inputs.branch }}
+        commit-message: ${{ inputs.commit-message }}
+        force-orphan: ${{ inputs.force-orphan }}
 
-    - name: "Ensure that the desired branch exists"
-      shell: bash
-      env:
-        BOT_USER: ${{ inputs.bot-user }}
-        BOT_EMAIL: ${{ inputs.bot-email }}
-        BRANCH: ${{ inputs.branch }}
-      run: | # zizmor: ignore[template-injection] I can't think of any other way to expand input.branch within comments
-        # Check the ${{ inputs.branch }} branch exists on remote
-        branch_exists=$(git ls-remote --heads origin "refs/heads/${BRANCH}" 2>&1)
-
-        # If the ${{ inputs.branch }} doesn't exist, then print error message and exit 1
-        if [ -z "$branch_exists" ]; then
-          echo "The $BRANCH branch does not exist. Creating $BRANCH."
-
-          # Create orphan branch
-          git checkout --orphan "$BRANCH"
-
-          # Unstage files to be committed
-          git rm --cached -r .
-
-          # Remove untracked files
-          git clean -fd
-
-          # Configure git username & email
-          git config user.name "$BOT_USER"
-          git config user.email "$BOT_EMAIL"
-
-          # Commit ${{ inputs.branch }} & push to origin
-          git commit --allow-empty -m "Create $BRANCH branch"
-          git push -u origin "$BRANCH"
-        else
-          # Fetch and switch to ${{ inputs.branch }}
-          git fetch origin "${BRANCH}:${BRANCH}"
-          git switch "$BRANCH"
-        fi
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
+    - uses: ansys/actions/_pr-doc-clean@feat/pr-documentation-deployment-and-cleanup
+      if: github.event.pull_request.state == 'closed'
       with:
-        level: "INFO"
-        message: >
-          Download the pr documentation artifact in a folder that has the same
-          name as the version number. Decompress artifact if required. Finally,
-          display the structure of the directory to verify that it has the right
-          layout.
-
-    - name: "Ensure existence of the root PR documentation directory"
-      shell: bash
-      run: |
-        if [[ -d pull/ ]]; then
-          echo "PR documentation folder already exists."
-        else
-          mkdir pull/
-          echo "PR documentation folder created."
-        fi
-
-    - name: "Ensure existence of the clean sub-directory corresponding to the current PR"
-      shell: bash
-      env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        if [[ -d pull/${PR_NUMBER} ]]; then
-          echo "Directory corresponding to this PR's documentation detected, cleaning ..."
-          rm -rf pull/${PR_NUMBER} && mkdir pull/${PR_NUMBER}
-        else
-          mkdir pull/${PR_NUMBER}
-          echo "Directory for deploying documentation of the PR created."
-        fi
-
-    - name: "Download the pr documentation artifact"
-      uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
-      with:
-        name: ${{ inputs.doc-artifact-name }}
-        path: pull/${{ github.event.pull_request.number }}
-
-    - name: "Update apt-get"
-      shell: bash
-      run: |
-        sudo apt-get update
-
-    - name: "Decompress artifact content"
-      shell: bash
-      if: inputs.decompress-artifact == 'true'
-      env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        sudo apt-get install -y cargo && cargo install ouch
-        export PATH="$HOME/.cargo/bin/:$PATH"
-        ouch --version
-        cd pull/${PR_NUMBER} && compressed_artifact=$(ls .)
-        ouch decompress $compressed_artifact
-        decompressed_artifact=$(ls -I "*${compressed_artifact##*.}")
-        mv $decompressed_artifact/* .
-        rm -rf $compressed_artifact $decompressed_artifact
-
-    - name: "Display structure of pull/${{ github.event.pull_request.number }}"
-      shell: bash
-      env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        ls -R pull/${PR_NUMBER}
-
-    # ------------------------------------------------------------------------
-
-    - uses: ansys/actions/_logging@main
-      with:
-        level: "INFO"
-        message: >
-          For deploying the documentation, a GitHub token or a deployment token
-          is required. The GitHub token is used when deploying to the current
-          repository while the deployment token is used to deploy to an external
-          repository.
-
-    - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
-      if: inputs.repository == 'current'
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-      with:
-        publish_dir: .
-        publish_branch: ${{ inputs.branch }}
-        github_token: ${{ inputs.token }}
-        commit_message: ${{ inputs.commit-message }}
-        keep_files: true
-        force_orphan: ${{ inputs.force-orphan }}
-
-    - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
-      if: inputs.repository != 'current'
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
-      with:
-        publish_dir: .
-        publish_branch: ${{ inputs.branch }}
-        personal_token: ${{ inputs.token }}
-        external_repository: ${{ inputs.repository }}
-        commit_message: ${{ inputs.commit-message }}
-        keep_files: true
-        force_orphan: ${{ inputs.force-orphan }}
+        token: ${{ inputs.token }}
+        bot-user: ${{ inputs.bot-user }}
+        bot-email: ${{ inputs.bot-email }}
+        repository: ${{ inputs.repository }}
+        branch: ${{ inputs.branch }}
+        commit-message: ${{ inputs.commit-message }}
+        force-orphan: ${{ inputs.force-orphan }}

--- a/doc/source/changelog/799.added.md
+++ b/doc/source/changelog/799.added.md
@@ -1,0 +1,1 @@
+pr documentation deployment and cleanup

--- a/doc/source/doc-actions/examples/doc-deploy-pr.yml
+++ b/doc/source/doc-actions/examples/doc-deploy-pr.yml
@@ -1,6 +1,6 @@
 # The same action takes care of both deployment and cleanup of PR documentation
-# Add these lines to your pull request workflow file to ensure
-# the action will be triggered when the PR is closed to ensure documentation cleanup:
+# Add these lines to your pull request workflow file to also trigger
+# the action when the PR is closed to ensure documentation cleanup:
 # on:
 #   pull_request:
 #     # opened, reopened, and synchronize are default for pull_request

--- a/doc/source/doc-actions/examples/doc-deploy-pr.yml
+++ b/doc/source/doc-actions/examples/doc-deploy-pr.yml
@@ -1,0 +1,36 @@
+# The same action takes care of both deployment and cleanup of PR documentation
+# Add these lines to your pull request workflow file to ensure
+# the action will be triggered when the PR is closed to ensure documentation cleanup:
+# on:
+#   pull_request:
+#     # opened, reopened, and synchronize are default for pull_request
+#     # closed - when the PR is closed (via merge or otherwise)
+#     types: [opened, reopened, synchronize, edited, labeled]
+
+# Add a condition to skip other jobs in the workflow when the PR is closed
+# For example, for the doc-build job which must be run before the PR can be deployed,
+# but doesn't need to run for cleaning up the PR documentation:
+
+# doc-build:
+#   name: "Doc build"
+#   # Skip when the PR is closed
+#   if: github.event.action != 'closed'
+#   runs-on: ubuntu-latest
+#   steps:
+#     - uses: ansys/actions/doc-build@{{ version }}
+#       with:
+#         python-version: ${{ '{{env.MAIN_PYTHON_VERSION}}' }}
+
+doc-deploy-pr:
+  name: "Deploy PR documentation"
+  runs-on: ubuntu-latest
+  needs: doc-build
+  # Run when the PR is closed i.e. when doc-build job is skipped
+  if: ${{ '{{ always() }}' }} && (needs.doc-build.result == 'success' || needs.doc-build.result == 'skipped')
+  steps:
+    - uses: ansys/actions/doc-deploy-pr@{{ version }}
+      with:
+        cname: ${{ '{{ env.DOCUMENTATION_CNAME }}' }}
+        token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
+        bot-user: ${{ '{{ secrets.PYANSYS_CI_BOT_USERNAME }}' }}
+        bot-email: ${{ '{{ secrets.PYANSYS_CI_BOT_EMAIL }}' }}

--- a/doc/source/doc-actions/index.rst
+++ b/doc/source/doc-actions/index.rst
@@ -26,6 +26,12 @@ Doc deploy stable action
 .. jinja:: doc-deploy-stable
     :file: _templates/action.rst.jinja
 
+Doc deploy pr action
+---------------------
+
+.. jinja:: doc-deploy-pr
+    :file: _templates/action.rst.jinja
+
 Doc changelog action
 --------------------
 


### PR DESCRIPTION
Closes #694, closes #327.

### Context
The current implementation unifies the _**deployment of the pr documentation**_ and _**pr documentation cleanup after pr closure**_ into a single action, the intention is to make the configuration required of the consuming workflow easy.

The typical configuration changes required for a consuming workflow will be as illustrated in [this example](https://github.com/ansys/actions/pull/802/files).

In the current implementation, a comment is added to the pr pointing the user to the deployed documentation (this happens only once i.e. when the documentation is freshly deployed, which is when the pr is first opened, or when it is first re-opened). A comment is also added when the pr is closed (either by merging or otherwise) letting the user know that the pr documentation has been removed. Here are some tests that have been done:
- Test on this repo: https://github.com/ansys/actions/pull/802
- Test on a different repo: https://github.com/ansys-internal/test-repo-moe/pull/4
