### PR TITLE
fix(wheelhouse): install from poetry.lock if present

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -148,15 +148,6 @@ runs:
       run: |
         python -m pip install build wheel
 
-    - name: "Check if specific target is requested"
-      id: specific-target-requested
-      shell: bash
-      env:
-        TARGET: ${{ inputs.target }}
-      run: |
-        echo "install_target=$( [[ "${TARGET}" == '' ]] && echo '.' || echo ".[${TARGET}]")" >> ${GITHUB_OUTPUT}
-        echo "wheelhouse_target=$( [[ "${TARGET}" == '' ]] && echo 'wheelhouse' || echo "${TARGET}-wheelhouse")" >> ${GITHUB_OUTPUT}
-
     - name: "Identify the build system"
       id: build-system
       shell: bash
@@ -167,7 +158,20 @@ runs:
           echo "BUILD_BACKEND=$(echo 'pip')" >> ${GITHUB_OUTPUT}
         fi
 
-    - name: "Install the library"
+    - name: "Check if specific target is requested"
+      id: specific-target-requested
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: |
+        if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
+          echo "install_target=$( [[ "${TARGET}" == '' ]] && echo '' || echo "--with ${TARGET}")" >> ${GITHUB_OUTPUT}
+        else
+          echo "install_target=$( [[ "${TARGET}" == '' ]] && echo '.' || echo ".[${TARGET}]")" >> ${GITHUB_OUTPUT}
+        fi
+        echo "wheelhouse_target=$( [[ "${TARGET}" == '' ]] && echo 'wheelhouse' || echo "${TARGET}-wheelhouse")" >> ${GITHUB_OUTPUT}
+
+    - name: "Install the library with the desired targets"
       env:
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -102,14 +102,6 @@ inputs:
     default: true
     type: boolean
 
-  working-directory:
-    description: |
-      Directory to execute this action. Useful for repositories containing
-      various Python libraries.
-    required: false
-    default: '.'
-    type: string
-
   attest-provenance:
     description: |
       Whether to generate build provenance attestations for wheelhouse
@@ -161,9 +153,8 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        echo "install_target=$( [[ "${TARGET}" == '' ]] && echo "${WORKING_DIRECTORY}" || echo "${WORKING_DIRECTORY}[${TARGET}]")" >> ${GITHUB_OUTPUT}
+        echo "install_target=$( [[ "${TARGET}" == '' ]] && echo '.' || echo ".[${TARGET}]")" >> ${GITHUB_OUTPUT}
         echo "wheelhouse_target=$( [[ "${TARGET}" == '' ]] && echo 'wheelhouse' || echo "${TARGET}-wheelhouse")" >> ${GITHUB_OUTPUT}
 
     - name: "Identify the build system"

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -102,6 +102,14 @@ inputs:
     default: true
     type: boolean
 
+  working-directory:
+    description: |
+      Directory to execute this action. Useful for repositories containing
+      various Python libraries.
+    required: false
+    default: '.'
+    type: string
+
   attest-provenance:
     description: |
       Whether to generate build provenance attestations for wheelhouse
@@ -153,16 +161,32 @@ runs:
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        echo "install_target=$( [[ "${TARGET}" == '' ]] && echo '.' || echo ".[${TARGET}]")" >> ${GITHUB_OUTPUT}
+        echo "install_target=$( [[ "${TARGET}" == '' ]] && echo "${WORKING_DIRECTORY}" || echo "${WORKING_DIRECTORY}[${TARGET}]")" >> ${GITHUB_OUTPUT}
         echo "wheelhouse_target=$( [[ "${TARGET}" == '' ]] && echo 'wheelhouse' || echo "${TARGET}-wheelhouse")" >> ${GITHUB_OUTPUT}
 
-    - name: "Install the library"
+    - name: "Identify the build system"
+      id: build-system
       shell: bash
+      run: |
+        if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
+          echo "BUILD_BACKEND=$(echo 'poetry')" >> ${GITHUB_OUTPUT}
+        else
+          echo "BUILD_BACKEND=$(echo 'pip')" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: "Install the library"
       env:
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
+        BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
+      shell: bash
       run: |
-        python -m pip install "${INSTALL_TARGET}"
+        if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
+          poetry install ${INSTALL_TARGET}
+        else
+          python -m pip install "${INSTALL_TARGET}"
+        fi
 
     - name: "Verify if importlib-metadata needs to be installed"
       id: needs-importlib-metadata

--- a/doc/source/changelog/805.fixed.md
+++ b/doc/source/changelog/805.fixed.md
@@ -1,0 +1,1 @@
+install from poetry.lock if present


### PR DESCRIPTION
Fix #789 by installing from the `poetry.lock` file if present. This pull-request also adds the `working-directory` input so mono-repos can build the wheelhouse for its various libraries, as the `working-directory` input is not supported by GitHub with the `uses` syntax.