### PR TITLE
fix(vulnerabilities): remove marshmallow dependency limit

### DIFF
--- a/check-vulnerabilities/requirements.txt
+++ b/check-vulnerabilities/requirements.txt
@@ -1,5 +1,4 @@
 bandit>=1.7,<2
 click>=7.0,<9
-marshmallow>=3.0,<4 # There is currently a bug in marshmallow 4.0.0 that causes safety to fail
 pygithub>=1.59,<2
 safety>=2.3,<4

--- a/doc/source/changelog/806.fixed.md
+++ b/doc/source/changelog/806.fixed.md
@@ -1,0 +1,1 @@
+remove marshmallow dependency limit


### PR DESCRIPTION
Changes introduced in https://github.com/ansys/actions/pull/780/ are no longer required. Packages are now compatible.