### PR TITLE
fix: uv in actions without venv creation

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -137,7 +137,7 @@ runs:
     - name: "Install twine"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         ${INSTALL_COMMAND} --upgrade pip twine
 

--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: "Install build and twine"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         ${INSTALL_COMMAND} build twine
 

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -156,7 +156,7 @@ runs:
     - name: "Update pip"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         $INSTALL_COMMAND -U pip
 
@@ -164,7 +164,7 @@ runs:
       if: ${{ inputs.install-build-and-wheel == 'true' }}
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         $INSTALL_COMMAND build wheel
 
@@ -181,7 +181,7 @@ runs:
     - name: "Install the library"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
       run: |
         ${INSTALL_COMMAND} "${INSTALL_TARGET}"
@@ -207,7 +207,7 @@ runs:
       if: steps.needs-importlib-metadata.outputs.needs_importlib_metadata == 'true'
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         $INSTALL_COMMAND importlib-metadata
 

--- a/check-licenses/action.yml
+++ b/check-licenses/action.yml
@@ -160,7 +160,7 @@ runs:
     - name: "Update pip"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         $INSTALL_COMMAND -U pip
 
@@ -174,7 +174,7 @@ runs:
     - name: Install ansys/pip-licenses main branch
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --no-cache' || 'python -m pip install --no-cache-dir' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system --no-cache' || 'python -m pip install --no-cache-dir' }}
       run: |
         $INSTALL_COMMAND external/pip-licenses
 
@@ -191,7 +191,7 @@ runs:
       shell: bash
       env:
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: ${INSTALL_COMMAND} "$INSTALL_TARGET"
 
     - name:  "Install wget on Windows"

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -136,7 +136,7 @@ runs:
       env:
         TOWNCRIER_VERSION: ${{ inputs.towncrier-version }}
         TOML_VERSION: ${{ inputs.toml-version }}
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         ${INSTALL_COMMAND} --upgrade pip towncrier==${TOWNCRIER_VERSION} toml==${TOML_VERSION}
 

--- a/hk-package-clean-except/action.yml
+++ b/hk-package-clean-except/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: "Install ghapi"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
 
         ${INSTALL_COMMAND} --upgrade pip

--- a/hk-package-clean-untagged/action.yml
+++ b/hk-package-clean-untagged/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: "Install ghapi"
       shell: bash
       env:
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
 
         ${INSTALL_COMMAND} --upgrade pip

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -298,7 +298,7 @@ runs:
       env:
         TOML_VERSION: ${{ inputs.toml-version }}
         PYPANDOC_BINARY_VERSION: ${{ inputs.pypandoc-binary-version }}
-        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python' || 'python -m pip install' }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
         ${INSTALL_COMMAND} --upgrade pip toml=="$TOML_VERSION"
         ${INSTALL_COMMAND} pypandoc-binary=="$PYPANDOC_BINARY_VERSION"


### PR DESCRIPTION
Some of our actions do not create venvs. For these actions, an extra flag needs to be passed to `uv` so it targets the python interpreter on the path.

Failed run: https://github.com/ansys/actions/actions/runs/14926657936/job/41933020321?pr=799
Testing this fix: https://github.com/ansys/actions/actions/runs/14927170869/job/41934585831?pr=799

