### PR TITLE
feat: Add breaking change section

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 # This file is required by the the action 'https://github.com/actions/labeler'
 # and used in the '.github/workflows/ci_cd_pr.yml' workflow
 
-# -- Labels based on PR title ------------------------------------------------
+# -- Labels based on PR head branch ------------------------------------------
 'fix':
   - head-branch: ['fix']
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -79,6 +79,10 @@
   description: Docker maintenance related
   color: 000075
 
+- name: 'breaking change'
+  description: Changes that break backward compatibility
+  color: ff0000
+
 # Hacktoberfest labels -------------------------------------------------------
 
 - name: 'hacktoberfest'

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -150,7 +150,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import get_first_letter_case
+        from parse_pr import get_first_letter_case
 
         pr_title = os.environ.get("PR_TITLE")
         get_first_letter_case(pr_title)
@@ -168,20 +168,23 @@ runs:
         token: ${{ inputs.token }}
         use-upper-case: true
 
-    - name: "Get conventional commit type from title"
+    - name: "Get conventional commit type"
       if: ${{ inputs.use-conventional-commits == 'true' }}
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BODY: ${{ github.event.pull_request.body }}
       shell: python
       run: |
         import os
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import get_conventional_commit_type
+        from parse_pr import get_conventional_commit_type
 
         pr_title = os.environ.get("PR_TITLE")
-        get_conventional_commit_type(pr_title)
+        pr_body = os.environ.get("PR_BODY")
+
+        get_conventional_commit_type(pr_title, pr_body)
 
     - name: "Get labels in the pull request"
       id: get-labels
@@ -205,7 +208,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import changelog_category_cc
+        from parse_pr import changelog_category_cc
 
         cc_type = ${{ env.CC_TYPE }}
         changelog_category_cc(cc_type)
@@ -220,7 +223,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import changelog_cateogry_labels
+        from parse_pr import changelog_cateogry_labels
 
         labels = os.environ.get("LABELS")
         changelog_cateogry_labels(labels)
@@ -248,7 +251,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import clean_pr_title
+        from parse_pr import clean_pr_title
 
         pr_title = os.environ.get("PR_TITLE")
         use_cc = True if os.environ.get("USE_CONVENTIONAL_COMMITS") == "true" else False
@@ -294,7 +297,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import add_towncrier_config
+        from parse_pr import add_towncrier_config
 
         repo_name = os.environ.get("REPO_NAME")
         org_name = "${{ github.repository_owner }}"
@@ -311,7 +314,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import rewrite_template
+        from parse_pr import rewrite_template
 
         template_status = rewrite_template(os.getenv('TEMPLATE'), os.getenv('FILENAME'))
 

--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -303,7 +303,7 @@ runs:
         import sys
         sys.path.insert(1, '${{ github.action_path }}/../python-utils/')
 
-        from parse_pr_title import save_env_variable
+        from parse_pr import save_env_variable
 
         # Whether or not to format the date in the CHANGELOG file - "true" or "false"
         format_date = os.environ.get("FORMAT_DATE")

--- a/doc/source/migrations/docs-changelog-setup.rst
+++ b/doc/source/migrations/docs-changelog-setup.rst
@@ -143,6 +143,11 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
     issue_format = "`#{issue} <https://github.com/{org-name}/{repo-name}/pull/{issue}>`_"
 
     [[tool.towncrier.type]]
+    directory = "breaking"
+    name = "Breaking change"
+    showcontent = true
+
+    [[tool.towncrier.type]]
     directory = "added"
     name = "Added"
     showcontent = true
@@ -240,6 +245,11 @@ Also, replace ``ansys.<product>.<library>`` with the name under ``tool.flit.modu
     template = "doc/changelog.d/changelog_template.jinja"
     title_format = "## [{version}](https://github.com/ansys/{repo-name}/releases/tag/v{version}) - {project_date}"
     issue_format = "[#{issue}](https://github.com/ansys/{repo-name}/pull/{issue})"
+
+    [[tool.towncrier.type]]
+    directory = "breaking"
+    name = "Breaking change"
+    showcontent = true
 
     [[tool.towncrier.type]]
     directory = "added"

--- a/python-utils/release_github_utils.py
+++ b/python-utils/release_github_utils.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 
 import pypandoc
-from parse_pr_title import get_towncrier_config_value, save_env_variable
+from parse_pr import get_towncrier_config_value, save_env_variable
 
 """Semantic version regex as found on semver.org:
 https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string"""

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -9,6 +9,11 @@ title_format = "`{version} <https://github.com/ansys/actions/releases/tag/v{vers
 issue_format = "`#{issue} <https://github.com/ansys/actions/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking change"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "added"
 name = "Added"
 showcontent = true


### PR DESCRIPTION
Adds checking for breaking change in the PR title and body. On repos following [conventionnal commits](https://www.conventionalcommits.org/en/v1.0.0/), this will greatly help:
- users to know what breaking changes are introduced in a specific version;
- developers to have an idea of how often they are breaking their API.

I think that this could be used as a metric to know whether a repo is ready to move to version `1.0.0`

Close #722