### PR TITLE
fix: avoid using pip cache with uv

### DIFF
--- a/_setup-python/action.yml
+++ b/_setup-python/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: true
     type: string
   use-cache:
-    description: 'Whether to use Python cache or not. Requires a pyproject.toml file.'
+    description: 'Whether to use Python/uv cache or not. Requires a pyproject.toml file.'
     required: true
     type: boolean
   provision-uv:
@@ -42,20 +42,25 @@ runs:
   using: "composite"
   steps:
 
+    # NOTE: When a workflow is triggered without using the cache, it can lead to a failure
+    # in the Post Run action sayng that the cache folder doesn't exist on disk.
+    # This is related to our use of uv to install packages, see https://github.com/ansys/actions/pull/811
     - name: "Set up Python using cache"
+      if: ${{ inputs.use-cache == 'true' && inputs.provision-uv == 'false'}}
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      if: inputs.use-cache == 'true'
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
         cache-dependency-path: 'pyproject.toml'
 
     - name: "Set up Python without using cache"
+      if: ${{ inputs.use-cache == 'false' || (inputs.use-cache == 'true' && inputs.provision-uv == 'true') }}
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
-      if: inputs.use-cache == 'false'
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: "Set up uv"
-      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
       if: ${{ inputs.provision-uv == 'true' }}
+      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      with:
+        enable-cache: ${{ inputs.use-cache }}


### PR DESCRIPTION
Seems like, for some workflows, the fact that we use `uv` and keep using `pip` cache by default leads to a workflow error when the post run action is performed. The associated error message is:

Error: Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.

See:
- failure when using cache (by default) https://github.com/ansys/actions/actions/runs/14945638158/job/41988577383
- success when disable the cache (manually) https://github.com/ansys/actions/actions/runs/14945529201
