### PR TITLE
fix: crash when reading pyproject (broken toml library)

### DIFF
--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -62,13 +62,6 @@ inputs:
     required: false
     type: string
 
-  toml-version:
-    description: |
-      Toml version used for retrieving the towncrier directory.
-    default: '0.10.2'
-    required: false
-    type: string
-
   ignore-changelogd:
     description: |
       Whether or not to ignore markdown files in doc/changelog.d/.
@@ -143,13 +136,6 @@ runs:
           fi
         fi
 
-    - name: "Install toml"
-      shell: bash
-      env:
-       TOML_VERSION: ${{ inputs.toml-version }}
-      run: |
-        python -m pip install --upgrade pip toml==${TOML_VERSION}
-
     - name: "Install docutils"
       shell: bash
       run: |
@@ -159,12 +145,12 @@ runs:
       shell: python
       run: |
         import os
-        import toml
+        import tomllib
 
         if os.path.exists("pyproject.toml"):
             # Load pyproject.toml
-            with open('pyproject.toml', 'r') as f:
-                config = toml.load(f)
+            with open('pyproject.toml', 'rb') as f:
+                config = tomllib.load(f)
                 try:
                     # Get towncrier directory
                     directory=config["tool"]["towncrier"]["directory"]

--- a/doc/source/changelog/809.fixed.md
+++ b/doc/source/changelog/809.fixed.md
@@ -1,0 +1,1 @@
+replace broken `toml` by `tomllib`: allow more contructs in pyproject.toml

--- a/doc/source/changelog/809.fixed.md
+++ b/doc/source/changelog/809.fixed.md
@@ -1,1 +1,0 @@
-replace broken `toml` by `tomllib`: allow more contructs in pyproject.toml

--- a/doc/source/changelog/816.fixed.md
+++ b/doc/source/changelog/816.fixed.md
@@ -1,0 +1,1 @@
+crash when reading pyproject (broken toml library)


### PR DESCRIPTION
Fixes #809

Replaces the outdated `toml` by the python stdlib's `tomllib`.

This might be deemed breaking since:

* I'm removing an input
* The action now requires python >= 3.11 (ubuntu 24.04 has 3.12 by default)