### PR TITLE
feat(build-library): allow to specify working-directory

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -72,6 +72,14 @@ inputs:
     default: true
     type: boolean
 
+  working-directory:
+     description: |
+       Directory to execute this action. Useful for repositories containing
+       various Python libraries.
+     required: false
+     default: '.'
+     type: string
+
   attest-provenance:
     description: |
       Whether to generate build provenance attestations for distribution
@@ -116,8 +124,10 @@ runs:
 
     - name: "Build distribution artifacts"
       shell: bash
+      env:
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        python -m build
+        python -m build --outdir dist "${WORKING_DIRECTORY}"
 
     - name: "Check build health"
       shell: bash

--- a/doc/source/changelog/820.added.md
+++ b/doc/source/changelog/820.added.md
@@ -1,0 +1,1 @@
+allow to specify working-directory


### PR DESCRIPTION
Allow to specify the working directory where the library is located. Useful when using this action in monorepos. Related with https://github.com/ansys/actions/pull/807.