### PR TITLE
fix(wheelhouse): virtual environment activation

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -288,8 +288,8 @@ runs:
       run: |
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
           ${ACTIVATE_VENV}
-          pip freeze | sed 's/\r$//' > wheel_reqs.txt
-          pip wheel -w wheelhouse -r wheel_reqs.txt
+          python -m pip freeze | sed 's/\r$//' > wheel_reqs.txt
+          python -m pip wheel -w wheelhouse -r wheel_reqs.txt
         else
           python -m pip wheel "${INSTALL_TARGET}" -w wheelhouse
         fi

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -287,7 +287,6 @@ runs:
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
       run: |
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
-          #${ACTIVATE_VENV}
           python -m pip freeze | sed 's/\r$//' > wheel_reqs.txt
           python -m pip wheel -w wheelhouse -r wheel_reqs.txt
         else

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -287,7 +287,7 @@ runs:
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
       run: |
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
-          ${ACTIVATE_VENV}
+          #${ACTIVATE_VENV}
           python -m pip freeze | sed 's/\r$//' > wheel_reqs.txt
           python -m pip wheel -w wheelhouse -r wheel_reqs.txt
         else

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -286,6 +286,9 @@ runs:
         ACTIVATE_VENV: ${{ steps.poetry-env.outputs.activate_env }}
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
       run: |
+        ${ACTIVATE_VENV}
+        python -m pip list
+
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
           python -m pip freeze | sed 's/\r$//' > wheel_reqs.txt
           python -m pip wheel -w wheelhouse -r wheel_reqs.txt

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -158,25 +158,56 @@ runs:
       env:
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        $INSTALL_COMMAND -U pip
+        ${INSTALL_COMMAND} -U pip
 
-    - name: "Optionally install build and wheel"
+    - name: "Set venv activation command"
+      shell: bash
+      id: activate-venv
+      run: |
+        if [[ ${{ runner.os }} == 'Windows' ]]; then
+          echo "command=$(echo '.venv/scripts/activate')" >> ${GITHUB_OUTPUT}
+        else
+          echo "command=$(echo 'source .venv/bin/activate')" >> ${GITHUB_OUTPUT}
+        fi
+
+    - name: "Create virtual environment"
+      shell: bash
+      env:
+        NEEDS_UV: ${{ inputs.use-uv }}
+        INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
+      run: |
+        if [[ ${NEEDS_UV }]]; then
+          uv venv --seed
+        else
+          python -m venv .venv
+        fi
+
+    - name: "Install build and wheel"
       if: ${{ inputs.install-build-and-wheel == 'true' }}
       shell: bash
       env:
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        $INSTALL_COMMAND build wheel
+        ${INSTALL_COMMAND} build wheel
 
     - name: "Identify the build system"
       id: build-system
       shell: bash
       run: |
         if [[ -f "pyproject.toml" ]] && grep -q 'build-backend = "poetry\.core\.masonry\.api"' "pyproject.toml"; then
-          echo "BUILD_BACKEND=$(echo 'poetry')" >> ${GITHUB_OUTPUT}
+          echo "BUILD_BACKEND=poetry" >> ${GITHUB_OUTPUT}
         else
-          echo "BUILD_BACKEND=$(echo 'pip')" >> ${GITHUB_OUTPUT}
+          echo "BUILD_BACKEND=pip" >> ${GITHUB_OUTPUT}
         fi
+
+    - name: "Install poetry"
+      if: steps.build-system.outputs.BUILD_BACKEND == 'poetry'
+      shell: bash
+      env:
+        ACTIVATE_VENV: ${{ steps.activate-venv.outputs.command }}
+      run: |
+        ${ACTIVATE_VENV}
+        python -m pip install poetry
 
     - name: "Check if specific target is requested"
       id: specific-target-requested
@@ -193,35 +224,16 @@ runs:
         fi
         echo "wheelhouse_target=$( [[ "${TARGET}" == '' ]] && echo 'wheelhouse' || echo "${TARGET}-wheelhouse")" >> ${GITHUB_OUTPUT}
 
-    - name: "Install poetry if needed (and configure it as needed - no auto poetry env + pipx + dedicated virtualenv)"
-      if: steps.build-system.outputs.BUILD_BACKEND == 'poetry'
-      id: poetry-env
-      shell: bash
-      env:
-        PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
-        PIPX_HOME: ${{ runner.temp }}/pipx/home
-      run: |
-        python -m pip install pipx
-        python -m pipx install poetry
-        echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH # zizmor: ignore[github-env]
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-        python -m venv .venv
-        if [[ ${{ runner.os }} == 'Windows' ]]; then
-          echo "activate_env=$(echo 'source .venv/scripts/activate')" >> ${GITHUB_OUTPUT}
-        else
-          echo "activate_env=$(echo 'source .venv/bin/activate')" >> ${GITHUB_OUTPUT}
-        fi
-
     - name: "Install the library with the desired targets"
       env:
+        ACTIVATE_VENV: ${{ steps.activate-venv.outputs.command }}
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
-        ACTIVATE_VENV: ${{ steps.poetry-env.outputs.activate_env }}
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
       shell: bash
       run: |
+        ${ACTIVATE_VENV}
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
-          ${ACTIVATE_VENV}
           poetry install ${INSTALL_TARGET}
         else
            ${INSTALL_COMMAND} "${INSTALL_TARGET}"
@@ -248,22 +260,23 @@ runs:
       if: steps.needs-importlib-metadata.outputs.needs_importlib_metadata == 'true'
       shell: bash
       env:
+        ACTIVATE_VENV: ${{ steps.activate-venv.outputs.command }}
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        $INSTALL_COMMAND importlib-metadata
+        ${ACTIVATE_VENV}
+        ${INSTALL_COMMAND} importlib-metadata
 
     - name: "Verify library is properly installed and get its version number"
       id: library-version
       shell: bash
       env:
-        ACTIVATE_VENV: ${{ steps.poetry-env.outputs.activate_env }}
+        ACTIVATE_VENV: ${{ steps.activate-venv.outputs.command }}
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
         LIBRARY_NAME: ${{ inputs.library-name }}
         NEEDS_IMPORTLIB_METADATA: ${{ steps.needs-importlib-metadata.outputs.needs_importlib_metadata }}
       run: |
-        if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
-          ${ACTIVATE_VENV}
-        fi
+        ${ACTIVATE_VENV}
+
         library_name="${LIBRARY_NAME}"
 
         if [ ${NEEDS_IMPORTLIB_METADATA} == 'true' ]; then
@@ -283,7 +296,7 @@ runs:
       shell: bash
       env:
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
-        ACTIVATE_VENV: ${{ steps.poetry-env.outputs.activate_env }}
+        ACTIVATE_VENV: ${{ steps.activate-venv.outputs.command }}
         BUILD_BACKEND: ${{ steps.build-system.outputs.BUILD_BACKEND }}
       run: |
         ${ACTIVATE_VENV}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -176,7 +176,7 @@ runs:
         NEEDS_UV: ${{ inputs.use-uv }}
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        if [[ ${NEEDS_UV }]]; then
+        if [[ ${NEEDS_UV} == 'true' ]]; then
           uv venv --seed
         else
           python -m venv .venv

--- a/doc/source/changelog/822.fixed.md
+++ b/doc/source/changelog/822.fixed.md
@@ -1,0 +1,1 @@
+virtual environment activation


### PR DESCRIPTION
Looks like activating the virtual environment when using Poetry causes some environment variables to be hidden by the new environment. This prevents projects from installing, for instance, from the private PIP indices despite having set the right environment variables.