### PR TITLE
feat: option for maximum number of pr doc deployment

### DIFF
--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -236,7 +236,7 @@ runs:
         fi
 
     - name: "Make a PR comment stating reason for not deploying pr documentation"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT > ${{ inputs.maximum-pr-doc-deployments }})
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT > inputs.maximum-pr-doc-deployments }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -246,21 +246,21 @@ runs:
           reached.
 
     - name: "Download the pr documentation artifact"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.doc-artifact-name }}
         path: pull/${{ github.event.pull_request.number }}
 
     - name: "Update apt-get"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       shell: bash
       run: |
         sudo apt-get update
 
     - name: "Decompress artifact content"
       shell: bash
-      if: inputs.decompress-artifact == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
+      if: ${{ inputs.decompress-artifact == 'true' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
@@ -274,7 +274,7 @@ runs:
         rm -rf $compressed_artifact $decompressed_artifact
 
     - name: "Display structure of pull/${{ github.event.pull_request.number }}"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -284,14 +284,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
           Generate the "robots.txt" file for guiding web crawlers (spiders)
 
     - name: "Generate 'robots.txt' file"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       uses: ansys/actions/_doc-gen-robots@main
       with:
         cname: ${{ inputs.cname }}
@@ -299,7 +299,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
@@ -309,7 +309,7 @@ runs:
           repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
-      if: inputs.repository == 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
+      if: ${{ inputs.repository == 'current' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -320,7 +320,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
-      if: inputs.repository != 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
+      if: ${{ inputs.repository != 'current' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -332,7 +332,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Make a PR comment the first time a PR documentation is deployed"
-      if: steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
+      if: ${{ steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -236,31 +236,31 @@ runs:
         fi
 
     - name: "Make a PR comment stating reason for not deploying pr documentation"
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT > inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) > fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body: >
           The documentation for this pull request will not be deployed. This is because the maximum number
-          of allowed deployments (${{ inputs.maximum-pr-doc-deployments }}) set for this repository has been
+          of allowed deployments (${{ fromJSON(inputs.maximum-pr-doc-deployments) }}) set for this repository has been
           reached.
 
     - name: "Download the pr documentation artifact"
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.doc-artifact-name }}
         path: pull/${{ github.event.pull_request.number }}
 
     - name: "Update apt-get"
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       shell: bash
       run: |
         sudo apt-get update
 
     - name: "Decompress artifact content"
       shell: bash
-      if: ${{ inputs.decompress-artifact == 'true' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ inputs.decompress-artifact == 'true' && fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
@@ -274,7 +274,7 @@ runs:
         rm -rf $compressed_artifact $decompressed_artifact
 
     - name: "Display structure of pull/${{ github.event.pull_request.number }}"
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -284,14 +284,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       with:
         level: "INFO"
         message: >
           Generate the "robots.txt" file for guiding web crawlers (spiders)
 
     - name: "Generate 'robots.txt' file"
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: ansys/actions/_doc-gen-robots@main
       with:
         cname: ${{ inputs.cname }}
@@ -299,7 +299,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: ${{ steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       with:
         level: "INFO"
         message: >
@@ -309,7 +309,7 @@ runs:
           repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
-      if: ${{ inputs.repository == 'current' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ inputs.repository == 'current' && fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -320,7 +320,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
-      if: ${{ inputs.repository != 'current' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ inputs.repository != 'current' && fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -332,7 +332,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Make a PR comment the first time a PR documentation is deployed"
-      if: ${{ steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= inputs.maximum-pr-doc-deployments }}
+      if: ${{ steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -235,14 +235,24 @@ runs:
           echo "DEPLOYMENT_COUNT=$(ls pull/ | wc -l)" >> ${GITHUB_OUTPUT}
         fi
 
+    - name: "Detect if deployment rejection comment had been previously added to the same PR"
+      if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) > fromJSON(inputs.maximum-pr-doc-deployments) }}
+      id: find-comment
+      uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: The documentation for this pull request will not be deployed.
+
     - name: "Make a PR comment stating reason for not deploying pr documentation"
       if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) > fromJSON(inputs.maximum-pr-doc-deployments) }}
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        edit-mode: replace
         body: >
           The documentation for this pull request will not be deployed. This is because the maximum number
-          of allowed deployments (${{ fromJSON(inputs.maximum-pr-doc-deployments) }}) set for this repository has been
+          of allowed deployments (${{ inputs.maximum-pr-doc-deployments }}) set for this repository has been
           reached.
 
     - name: "Download the pr documentation artifact"

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -62,6 +62,12 @@ inputs:
     required: true
     type: string
 
+  maximum-pr-doc-deployments:
+    description: |
+      The maximum number of pull requests documentation allowed to be deployed.
+    required: true
+    type: number
+
   # Optional inputs
 
   doc-artifact-name:
@@ -199,36 +205,62 @@ runs:
           echo "PR documentation folder created."
         fi
 
-    - name: "Ensure existence of the clean sub-directory corresponding to the current PR"
-      id: create-pr-directory
+    - name: "Ensure a clean sub-directory corresponding to the current PR and count number of current deployments"
+      id: create-pull-directory
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         if [[ -d pull/${PR_NUMBER} ]]; then
+          # This means this is a redeployment
+          echo "FIRST_TIME_DEPLOYMENT=false" >> ${GITHUB_OUTPUT}
+
           echo "Directory corresponding to this PR's documentation detected, cleaning ..."
-          rm -rf pull/${PR_NUMBER} && mkdir pull/${PR_NUMBER}
-        else
+          rm -rf pull/${PR_NUMBER}
+          
+          # Count the number of deployments before creating the sub-directory
+          # This ensures correct behaviour in the case of redeployments
+          echo "DEPLOYMENT_COUNT=$(ls pull/ | wc -l)" >> ${GITHUB_OUTPUT}
+
           mkdir pull/${PR_NUMBER}
-          echo "Directory for deploying documentation of the PR created."
+        else
           # This means this is the first time the PR documentation is being deployed
           echo "FIRST_TIME_DEPLOYMENT=true" >> ${GITHUB_OUTPUT}
+
+          mkdir pull/${PR_NUMBER}
+          echo "Directory for deploying documentation of the PR created."
+
+          # Count the number of deployments after creating the sub-directory
+          # This ensures accurate behaviour for first time deployments
+          echo "DEPLOYMENT_COUNT=$(ls pull/ | wc -l)" >> ${GITHUB_OUTPUT}
         fi
 
+    - name: "Make a PR comment stating reason for not deploying pr documentation"
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT >= ${{ inputs.maximum-pr-doc-deployments }})
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: >
+          The documentation for this pull request will not be deployed. This is because the maximum number
+          of allowed deployments (${{ inputs.maximum-pr-doc-deployments }}) set for this repository has been
+          reached.
+
     - name: "Download the pr documentation artifact"
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.doc-artifact-name }}
         path: pull/${{ github.event.pull_request.number }}
 
     - name: "Update apt-get"
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       shell: bash
       run: |
         sudo apt-get update
 
     - name: "Decompress artifact content"
       shell: bash
-      if: inputs.decompress-artifact == 'true'
+      if: inputs.decompress-artifact == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
@@ -242,6 +274,7 @@ runs:
         rm -rf $compressed_artifact $decompressed_artifact
 
     - name: "Display structure of pull/${{ github.event.pull_request.number }}"
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -251,12 +284,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
           Generate the "robots.txt" file for guiding web crawlers (spiders)
 
     - name: "Generate 'robots.txt' file"
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       uses: ansys/actions/_doc-gen-robots@main
       with:
         cname: ${{ inputs.cname }}
@@ -264,6 +299,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
@@ -273,7 +309,7 @@ runs:
           repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
-      if: inputs.repository == 'current'
+      if: inputs.repository == 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -284,7 +320,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
-      if: inputs.repository != 'current'
+      if: inputs.repository != 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -296,7 +332,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Make a PR comment the first time a PR documentation is deployed"
-      if: steps.create-pr-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true'
+      if: steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -217,7 +217,7 @@ runs:
 
           echo "Directory corresponding to this PR's documentation detected, cleaning ..."
           rm -rf pull/${PR_NUMBER}
-          
+
           # Count the number of deployments before creating the sub-directory
           # This ensures correct behaviour in the case of redeployments
           echo "DEPLOYMENT_COUNT=$(ls pull/ | wc -l)" >> ${GITHUB_OUTPUT}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -236,7 +236,7 @@ runs:
         fi
 
     - name: "Make a PR comment stating reason for not deploying pr documentation"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT >= ${{ inputs.maximum-pr-doc-deployments }})
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT > ${{ inputs.maximum-pr-doc-deployments }})
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -246,21 +246,21 @@ runs:
           reached.
 
     - name: "Download the pr documentation artifact"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: ${{ inputs.doc-artifact-name }}
         path: pull/${{ github.event.pull_request.number }}
 
     - name: "Update apt-get"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       shell: bash
       run: |
         sudo apt-get update
 
     - name: "Decompress artifact content"
       shell: bash
-      if: inputs.decompress-artifact == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
+      if: inputs.decompress-artifact == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
@@ -274,7 +274,7 @@ runs:
         rm -rf $compressed_artifact $decompressed_artifact
 
     - name: "Display structure of pull/${{ github.event.pull_request.number }}"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       shell: bash
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -284,14 +284,14 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
           Generate the "robots.txt" file for guiding web crawlers (spiders)
 
     - name: "Generate 'robots.txt' file"
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       uses: ansys/actions/_doc-gen-robots@main
       with:
         cname: ${{ inputs.cname }}
@@ -299,7 +299,7 @@ runs:
     # ------------------------------------------------------------------------
 
     - uses: ansys/actions/_logging@main
-      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }}
+      if: steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }}
       with:
         level: "INFO"
         message: >
@@ -309,7 +309,7 @@ runs:
           repository.
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ github.repository }} repository"
-      if: inputs.repository == 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
+      if: inputs.repository == 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -320,7 +320,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Deploy to ${{ inputs.branch }} branch of ${{ inputs.repository }}"
-      if: inputs.repository != 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
+      if: inputs.repository != 'current' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
         publish_dir: .
@@ -332,7 +332,7 @@ runs:
         force_orphan: ${{ inputs.force-orphan }}
 
     - name: "Make a PR comment the first time a PR documentation is deployed"
-      if: steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT < ${{ inputs.maximum-pr-doc-deployments }})
+      if: steps.create-pull-directory.outputs.FIRST_TIME_DEPLOYMENT == 'true' && (steps.create-pull-directory.outputs.DEPLOYMENT_COUNT <= ${{ inputs.maximum-pr-doc-deployments }})
       uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}

--- a/_pr-doc-deployment/action.yml
+++ b/_pr-doc-deployment/action.yml
@@ -62,12 +62,6 @@ inputs:
     required: true
     type: string
 
-  maximum-pr-doc-deployments:
-    description: |
-      The maximum number of pull requests documentation allowed to be deployed.
-    required: true
-    type: number
-
   # Optional inputs
 
   doc-artifact-name:
@@ -118,6 +112,13 @@ inputs:
     required: false
     default: true
     type: string
+
+  maximum-pr-doc-deployments:
+    description: |
+      The maximum number of pull requests documentation allowed to be deployed.
+    required: false
+    default: 5
+    type: number
 
 runs:
   using: "composite"
@@ -241,7 +242,7 @@ runs:
       uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body-includes: The documentation for this pull request will not be deployed.
+        body-includes: Pull request documentation preview limit
 
     - name: "Make a PR comment stating reason for not deploying pr documentation"
       if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) > fromJSON(inputs.maximum-pr-doc-deployments) }}
@@ -251,9 +252,8 @@ runs:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         edit-mode: replace
         body: >
-          The documentation for this pull request will not be deployed. This is because the maximum number
-          of allowed deployments (${{ inputs.maximum-pr-doc-deployments }}) set for this repository has been
-          reached.
+          Pull request documentation preview limit (${{ inputs.maximum-pr-doc-deployments }})
+          reached: skipping documentation deployment for this pull request.
 
     - name: "Download the pr documentation artifact"
       if: ${{ fromJSON(steps.create-pull-directory.outputs.DEPLOYMENT_COUNT) <= fromJSON(inputs.maximum-pr-doc-deployments) }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -124,7 +124,7 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_pr-doc-deployment@main
+    - uses: ansys/actions/_pr-doc-deployment@feat/add-max-no-pr-doc-preview-action
       if: github.event.pull_request.state == 'open'
       with:
         cname: ${{ inputs.cname }}
@@ -139,7 +139,7 @@ runs:
         force-orphan: ${{ inputs.force-orphan }}
         maximum-pr-doc-deployments: ${{ inputs.maximum-pr-doc-deployments }}
 
-    - uses: ansys/actions/_pr-doc-clean@main
+    - uses: ansys/actions/_pr-doc-clean@feat/add-max-no-pr-doc-preview-action
       if: github.event.pull_request.state == 'closed'
       with:
         cname: ${{ inputs.cname }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -63,12 +63,6 @@ inputs:
     required: true
     type: string
 
-  maximum-pr-doc-deployments:
-    description: |
-      The maximum number of deployable pull requests documentation.
-    required: true
-    type: number
-
   # Optional inputs
 
   doc-artifact-name:
@@ -119,6 +113,13 @@ inputs:
     required: false
     default: true
     type: string
+
+  maximum-pr-doc-deployments:
+    description: |
+      The maximum number of deployable pull requests documentation.
+    required: false
+    default: 5
+    type: number
 
 runs:
   using: "composite"

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -68,7 +68,7 @@ inputs:
       The maximum number of deployable pull requests documentation.
     required: true
     type: number
-      
+
   # Optional inputs
 
   doc-artifact-name:

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -125,7 +125,7 @@ runs:
   using: "composite"
   steps:
 
-    - uses: ansys/actions/_pr-doc-deployment@feat/add-max-no-pr-doc-preview-action
+    - uses: ansys/actions/_pr-doc-deployment@main
       if: github.event.pull_request.state == 'open'
       with:
         cname: ${{ inputs.cname }}
@@ -140,7 +140,7 @@ runs:
         force-orphan: ${{ inputs.force-orphan }}
         maximum-pr-doc-deployments: ${{ inputs.maximum-pr-doc-deployments }}
 
-    - uses: ansys/actions/_pr-doc-clean@feat/add-max-no-pr-doc-preview-action
+    - uses: ansys/actions/_pr-doc-clean@main
       if: github.event.pull_request.state == 'closed'
       with:
         cname: ${{ inputs.cname }}

--- a/doc-deploy-pr/action.yml
+++ b/doc-deploy-pr/action.yml
@@ -63,6 +63,12 @@ inputs:
     required: true
     type: string
 
+  maximum-pr-doc-deployments:
+    description: |
+      The maximum number of deployable pull requests documentation.
+    required: true
+    type: number
+      
   # Optional inputs
 
   doc-artifact-name:
@@ -131,6 +137,7 @@ runs:
         branch: ${{ inputs.branch }}
         commit-message: ${{ inputs.commit-message }}
         force-orphan: ${{ inputs.force-orphan }}
+        maximum-pr-doc-deployments: ${{ inputs.maximum-pr-doc-deployments }}
 
     - uses: ansys/actions/_pr-doc-clean@main
       if: github.event.pull_request.state == 'closed'

--- a/doc/source/changelog/823.added.md
+++ b/doc/source/changelog/823.added.md
@@ -1,0 +1,1 @@
+option for maximum number of pr doc deployment

--- a/doc/source/doc-actions/examples/doc-deploy-pr.yml
+++ b/doc/source/doc-actions/examples/doc-deploy-pr.yml
@@ -34,3 +34,4 @@ doc-deploy-pr:
         token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
         bot-user: ${{ '{{ secrets.PYANSYS_CI_BOT_USERNAME }}' }}
         bot-email: ${{ '{{ secrets.PYANSYS_CI_BOT_EMAIL }}' }}
+        maximum-pr-doc-deployments: 3


### PR DESCRIPTION
Provides a default mechanism allowing users of `ansys/actions/doc-deploy-pr` to limit the number of pull request documentation that can be deployed.

Test: see https://github.com/ansys-internal/test-repo-moe/pull/7 and https://github.com/ansys-internal/test-repo-moe/pull/8