### PR TITLE
chore: update uv settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,7 @@ updates:
         patterns:
           - "docker/setup-qemu-action"
           - "pypa/cibuildwheel"
+          - "astral-sh/setup-uv"
       # Actions associated to our release composite actions
       release-related-actions:
         patterns:

--- a/_setup-python/action.yml
+++ b/_setup-python/action.yml
@@ -34,7 +34,19 @@ inputs:
     type: boolean
   provision-uv:
     description: 'Whether to provision uv alongside Python'
-    default: false
+    required: true
+    type: boolean
+  prune-uv-cache:
+    description: |
+      Whether to prune uv cache or not. This input only has an effect if
+      ``provision-uv`` is set to ``true``. If ``true``, the cache is pruned. If ``false``,
+      the cache is not pruned. By default it is set to ``true``.
+
+      .. note::
+
+        When uv cache is pruned, pre-built wheels are removed but wheels built from source
+        are retained.
+
     required: true
     type: boolean
 
@@ -61,6 +73,7 @@ runs:
 
     - name: "Set up uv"
       if: ${{ inputs.provision-uv == 'true' }}
-      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       with:
         enable-cache: ${{ inputs.use-cache }}
+        prune-cache: ${{ inputs.prune-uv-cache }}

--- a/check-actions-security/action.yml
+++ b/check-actions-security/action.yml
@@ -69,7 +69,7 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: "Install uv"
-      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
 
     - name: "Install zizmor and verify installation"
       shell: bash

--- a/doc/source/changelog/825.maintenance.md
+++ b/doc/source/changelog/825.maintenance.md
@@ -1,0 +1,1 @@
+update uv settings


### PR DESCRIPTION
While checking the current main status this warning appeared

![image](https://github.com/user-attachments/assets/f9287418-18fd-4dd2-8233-008d2114522a)

Seems like the default glob pattern have been updated and we could leverage that to match our default behavior (use of `pyproject.toml`). Also:
- Action `astral-sh/setup-uv` was not tracked by dependabot so it has been added.
- A new input has been added to `actions/_setup-python` to allow state if `uv` cache should be pruned or not. The default value is following `setup-uv`'s default behavior, see https://github.com/astral-sh/setup-uv?tab=readme-ov-file#disable-cache-pruning for more information.