### PR TITLE
fix: build wheelhouse with poetry

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -203,7 +203,7 @@ runs:
       run: |
         python -m pip install pipx
         python -m pipx install poetry
-        python -m pipx upgrade poetry
+        python -m pipx inject poetry poetry-plugin-export
         echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH # zizmor: ignore[github-env]
         echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
         python -m venv .venv

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -203,6 +203,7 @@ runs:
       run: |
         python -m pip install pipx
         python -m pipx install poetry
+        python -m pipx upgrade poetry
         echo "${{ runner.temp }}/pipx/bin" >> $GITHUB_PATH # zizmor: ignore[github-env]
         echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
         python -m venv .venv

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -288,7 +288,7 @@ runs:
       run: |
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
           ${ACTIVATE_VENV}
-          pip freeze | sed 's/\r$//' > wheel_reqs.txt
+          poetry export --without-hashes --format=requirements.txt --output=wheel_reqs.txt
           pip wheel -w wheelhouse -r wheel_reqs.txt
         else
           python -m pip wheel "${INSTALL_TARGET}" -w wheelhouse

--- a/doc/source/changelog/826.fixed.md
+++ b/doc/source/changelog/826.fixed.md
@@ -1,0 +1,1 @@
+build wheelhouse with poetry


### PR DESCRIPTION
This PR strengthen the compatibility of the `build-wheelhouse` action with `poetry`.

Currently, if one uses the main branch, the following error might appear https://github.com/ansys/pydpf-composites/actions/runs/15046028749/job/42288662063. Long story short, `pip freeze` doesn't use the revision defined in the poetry lock file and that can lead to a failure when building the wheelhouse. In the workflow failure, the project was installed with revision "1453403c76957981c84432cf67b43932ca9e99a5" while pip freeze doesn't contain this information and leads to the latest reference in main, i.e. revision "06170e14d2f47a9e53b59015b72e7b0dd897af9c".

This changes are successfully tested in https://github.com/ansys/pydpf-composites/actions/runs/15069361200

