### PR TITLE
ci: remove dependabot cooldown ftm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,10 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "pip"
     directories:
       - "/requirements"
     schedule:
       interval: "daily"
-    cooldown:
-      default-days: 7
-      include:
-        - "*"  # Include all dependencies in cooldown
-      exclude:
-        - "ansys-sphinx-theme"
     commit-message:
       prefix: "build(pip)"
     labels:


### PR DESCRIPTION
Assuming that our lack of updates from dependabot is associated to the fact the github actions are not yet handled by the cooldown feature, we should avoid using it for the moment.

Also, JSYK, the compatibility with `pip` is not yet dry as install targets are not well handled, see https://github.com/dependabot/dependabot-core/issues/12102