### PR TITLE
build(actions): downgrade awalsh128/cache-apt-pkgs-action due to errors

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -149,7 +149,7 @@ runs:
         fi
 
     - name: "Cache apt packages needed"
-      uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d # v1.5.0
+      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
       if: inputs.skip-dependencies-cache == 'false' && steps.needed-dependencies.outputs.NEEDED_DEPS != ''
       with:
         packages: ${{ steps.needed-dependencies.outputs.NEEDED_DEPS }}

--- a/doc/source/changelog/845.dependencies.md
+++ b/doc/source/changelog/845.dependencies.md
@@ -1,0 +1,1 @@
+bump awalsh128/cache-apt-pkgs-action from 1.4.3 to 1.5.0 in /_doc-build-linux in the doc-related-actions group across 1 directory

--- a/doc/source/changelog/845.dependencies.md
+++ b/doc/source/changelog/845.dependencies.md
@@ -1,1 +1,0 @@
-bump awalsh128/cache-apt-pkgs-action from 1.4.3 to 1.5.0 in /_doc-build-linux in the doc-related-actions group across 1 directory

--- a/doc/source/changelog/856.dependencies.md
+++ b/doc/source/changelog/856.dependencies.md
@@ -1,0 +1,1 @@
+Downgrade awalsh128/cache-apt-pkgs-action due to errors


### PR DESCRIPTION
While testing new changes, I found that the latest version of `awalsh128/cache-apt-pkgs-action` leads to errors on some packages, see https://github.com/awalsh128/cache-apt-pkgs-action/issues/159

Since `v1.5.0` is tagged as `pre-release` version, we should probably downgrade until it gets fixed and a stable release is released.