### PR TITLE
feat: Prepend link to migration guide in GitHub release notes

### DIFF
--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -247,11 +247,11 @@ jobs:
       uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
       with:
         body: >
-          If you are migrating the actions of your project to a new major release, breaking changes can be expected!
+          If you are migrating the actions of your project to a new major release, breaking changes can be expected.
 
-          To make sure everything is compatible with your current workflow, please refer to the
+          To make sure everything is compatible with your current workflow, refer to the
           [Migration Guide](${{ steps.link-migration-guide.outputs.LINK }}) to find out more about new features
-          and potential breaking changes!
+          and potential breaking changes.
         generate_release_notes: true
         files: |
           documentation-html.zip

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -236,11 +236,12 @@ jobs:
 
     - name: "Generate link to migration guide for current release"
       id: link-migration-guide
+      env:
+        MAJOR: ${{ needs.rolling-release.outputs.tag_major }}
       run: |
         BASE_LINK="https://actions.docs.ansys.com/version/stable/migrations/index.html#version-v"
         # Append version number to point to specific entry in the migration guide
-        MAJOR="${{ needs.rolling-release.outputs.tag_major }}"
-        LINK="${BASE_LINK}${MAJOR}"
+        LINK="${BASE_LINK}${{ env.MAJOR }}"
         echo "LINK=${LINK}" >> $GITHUB_OUTPUT
 
     - name: "Release to GitHub"

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -187,6 +187,8 @@ jobs:
     name: "Release"
     runs-on: ubuntu-latest
     needs: [doc-build, tests, rolling-release]
+    env:
+        MAJOR: ${{ needs.rolling-release.outputs.tag_major }}
     permissions:
       id-token: write
       contents: write
@@ -236,12 +238,10 @@ jobs:
 
     - name: "Generate link to migration guide for current release"
       id: link-migration-guide
-      env:
-        MAJOR: ${{ needs.rolling-release.outputs.tag_major }}
       run: |
         BASE_LINK="https://actions.docs.ansys.com/version/stable/migrations/index.html#version-v"
         # Append version number to point to specific entry in the migration guide
-        LINK="${BASE_LINK}${{ env.MAJOR }}"
+        LINK="${BASE_LINK}${MAJOR}"
         echo "LINK=${LINK}" >> $GITHUB_OUTPUT
 
     - name: "Release to GitHub"
@@ -251,8 +251,8 @@ jobs:
           If you are migrating the actions of your project to a new major release, breaking changes can be expected.
 
           To make sure everything is compatible with your current workflow, refer to the
-          [Migration Guide](${{ steps.link-migration-guide.outputs.LINK }}) to find out more about new features
-          and potential breaking changes.
+          [Migration Guide for v${{ env.MAJOR }}](${{ steps.link-migration-guide.outputs.LINK }}) to find out more
+          about new features and potential breaking changes.
         generate_release_notes: true
         files: |
           documentation-html.zip

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -20,6 +20,8 @@ jobs:
   rolling-release:
     name: "Rolling release"
     runs-on: ubuntu-latest
+    outputs:
+      tag_major: ${{ steps.current-branch-tag-validity.outputs.MAJOR }}
     env:
       REF_NAME: ${{ github.ref_name }}
       BASE_REF: ${{ github.event.base_ref }}
@@ -184,7 +186,7 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    needs: [doc-build, tests]
+    needs: [doc-build, tests, rolling-release]
     permissions:
       id-token: write
       contents: write
@@ -232,9 +234,24 @@ jobs:
         skip-existing: false
         verbose: true
 
+    - name: "Generate link to migration guide for current release"
+      id: link-migration-guide
+      run: |
+        BASE_LINK="https://actions.docs.ansys.com/version/stable/migrations/index.html#version-v"
+        # Append version number to point to specific entry in the migration guide
+        MAJOR="${{ needs.rolling-release.outputs.tag_major }}"
+        LINK="${BASE_LINK}${MAJOR}"
+        echo "LINK=${LINK}" >> $GITHUB_OUTPUT
+
     - name: "Release to GitHub"
       uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
       with:
+        body: >
+          If you are migrating the actions of your project to a new major release, breaking changes can be expected!
+
+          To make sure everything is compatible with your current workflow, please refer to the
+          [Migration Guide](${{ steps.link-migration-guide.outputs.LINK }}) to find out more about new features
+          and potential breaking changes!
         generate_release_notes: true
         files: |
           documentation-html.zip

--- a/doc/source/changelog/860.added.md
+++ b/doc/source/changelog/860.added.md
@@ -1,0 +1,1 @@
+Prepend link to migration guide in github release notes


### PR DESCRIPTION
This PR introduces a minor change to the release process of the ``ansys/actions`` project as requested in #813: A short message is prepended to the release notes, containing a link to the section of the migration guide (https://actions.docs.ansys.com/version/stable/migrations/index.html#migration-guide) for the current major version and warning users for potential breaking changes when updating actions from a prior (major) version. 
Going forward, this short message will be provided in the release notes of every new release (not only the first one of a new major version).
This small feature is implemented in an attempt to enhance the information provided to individual project owners making use of ``ansys/actions``, in particular in the context of dependency upgrades triggered by ``dependabot``.

Since the release to GitHub process of the ``ansys/actions`` project actually does not use a custom action, but is based on ``softprops/action-gh-release`` (see documentation here https://github.com/softprops/action-gh-release) instead, the changes introduced are limited to the ``.github/workflows/ci_cd_release.yml`` file.
The implementation is designed with release ``v10`` and beyond in mind: It does not observe the slight deviations in versioning (and therefore in formatting of the links to the migration guide) existing for recent major releases (8.2 and 9.0) and expects versions of the form ``v10``, ``v11``, etc.. as was the case for ``v8`` and earlier. 
However, the suggested implementation could easily be adapted to account for special cases and should always generate a functional link to the migration guide (only redirecting to the top of the page rather than to the desired section in case of an unexpected format for a future version number).

Close #813