### PR TITLE
chore: improve smoke tests handling

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -147,6 +147,16 @@ inputs:
     required: false
     type: string
 
+outputs:
+
+  activate-venv:
+    description: |
+      Command to activate the virtual environment created by this action.
+      This can be used in subsequent steps within the same job to perform
+      certain actions in the context of the virtual environment, such as
+      running smoke tests.
+    value: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
+
 runs:
   using: "composite"
   steps:

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -151,10 +151,9 @@ outputs:
 
   activate-venv:
     description: |
-      Command to activate the virtual environment created by this action.
-      This can be used in subsequent steps within the same job to perform
-      certain actions in the context of the virtual environment, such as
-      running smoke tests.
+      Command used to activate the virtual environment set up by this action.
+      It can be reused in later steps of the same job to execute tasks within
+      the virtual environment, such as running smoke tests.
     value: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
 
 runs:

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -138,15 +138,6 @@ inputs:
     required: false
     type: boolean
 
-  smoke-test-module:
-    description: |
-      Import path of a Python module to test (e.g. ansys.product.core). If
-      provided, the action will run a simple smoke test to verify that the
-      module can be imported and that it defines a __version__ attribute.
-    default: ''
-    required: false
-    type: string
-
 outputs:
 
   activate-venv:
@@ -407,14 +398,3 @@ runs:
         skip-install: true
         checkout: false
         whitelist-license-check: ${{ inputs.whitelist-license-check }}
-
-    - name: Run smoke test
-      if: inputs.smoke-test-module != ''
-      env:
-        ACTIVATE_VENV: ${{ steps.virtual-environment-activation-command.outputs.ACTIVATE_VENV }}
-        MODULE: ${{ inputs.smoke-test-module }}
-      shell: bash
-      run: |
-        ${ACTIVATE_VENV}
-        python -c "import ${MODULE}; from ${MODULE} import __version__; print(f'Imported: {${MODULE}}, version: {__version__}')"
-

--- a/doc/source/changelog/861.maintenance.md
+++ b/doc/source/changelog/861.maintenance.md
@@ -1,0 +1,1 @@
+Improve smoke tests handling


### PR DESCRIPTION
Closes #859.

I propose keeping what was initially done by @SMoraisAnsys (i.e. current behavior of `smoke-test-module`) and simply adding an output like @germa89 suggested for custom smoke testing.

That is simple and avoids having to cram several smoke test lines into one single string input.

Tested and working: https://github.com/ansys/pymapdl/actions/runs/15282156639?pr=3959