### PR TITLE
fix: missing environment variable on PyPI releasing

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -174,3 +174,5 @@ runs:
         TWINE_USERNAME: ${{ inputs.twine-username }}
         TWINE_PASSWORD: ${{ inputs.twine-token }}
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
+        LIBRARY_NAME: ${{ inputs.library-name }}
+

--- a/doc/source/changelog/880.fixed.md
+++ b/doc/source/changelog/880.fixed.md
@@ -1,1 +1,1 @@
-Missing env var on pypi releasing
+Missing environment variable on pypi releasing

--- a/doc/source/changelog/880.fixed.md
+++ b/doc/source/changelog/880.fixed.md
@@ -1,0 +1,1 @@
+Missing env var on pypi releasing


### PR DESCRIPTION
This is causing the release to PyPI action to fail. We need to fix it and patch release.