### PR TITLE
fix(release-actions): raise warning if not using trusted publishers

### DIFF
--- a/doc/source/changelog/883.fixed.md
+++ b/doc/source/changelog/883.fixed.md
@@ -1,0 +1,1 @@
+Raise warning if not using trusted publishers

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -110,6 +110,17 @@ runs:
   using: "composite"
   steps:
 
+    # TODO: ansys/actions@v11 will enforce the use of trusted publishers
+    - name: "Warn user if not using trusted publishers"
+      if: ${{ inputs.use-trusted-publisher == 'false' }}
+      uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v11 will remove support for releases using PyPI tokens.
+          Please contact the PyAnsys Core Team at pyansys.core@ansys.com for
+          enabling trusted publishers releases in your project.
+
     - name: "Release to the public PyPI index"
       uses: ansys/actions/_release-pypi@main
       with:

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -110,6 +110,17 @@ runs:
   using: "composite"
   steps:
 
+    # TODO: ansys/actions@v11 will enforce the use of trusted publishers
+    - name: "Warn user if not using trusted publishers"
+      if: ${{ inputs.use-trusted-publisher == 'false' }}
+      uses: ansys/actions/_logging@main
+      with:
+        level: "WARNING"
+        message: >
+          Ansys Actions v11 will remove support for releases using PyPI tokens.
+          Please contact the PyAnsys Core Team at pyansys.core@ansys.com for
+          enabling trusted publishers releases in your project.
+
     - name: "Release to test PyPI index"
       uses: ansys/actions/_release-pypi@main
       with:


### PR DESCRIPTION
Related with #882. Raises a deprecation warning if not using the trusted publishers solution when releasing a package to the public domain.