### PR TITLE
fix: missing skip-existing command handling

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -159,20 +159,20 @@ runs:
         SKIP_EXISTING: ${{ inputs.skip-existing }}
       run: |
         if [[ "${SKIP_EXISTING}" == 'true' ]]; then
-          echo "SKIP_EXISTING=$(echo '--skip-existing')" >> ${GITHUB_OUTPUT}
+          echo "SKIP_EXISTING_CMD=$(echo '--skip-existing')" >> ${GITHUB_OUTPUT}
         else
-          echo "SKIP_EXISTING=$(echo '')" >> ${GITHUB_OUTPUT}
+          echo "SKIP_EXISTING_CMD=$(echo '')" >> ${GITHUB_OUTPUT}
         fi
 
     - name: "Upload artifacts to PyPi"
       shell: bash
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'false'
       run: |
-        python -m twine upload --verbose $SKIP_EXISTING ${LIBRARY_NAME}-artifacts/*.whl
-        python -m twine upload --verbose $SKIP_EXISTING ${LIBRARY_NAME}-artifacts/*.tar.gz
+        python -m twine upload --verbose ${SKIP_EXISTING_CMD} ${LIBRARY_NAME}-artifacts/*.whl
+        python -m twine upload --verbose ${SKIP_EXISTING_CMD} ${LIBRARY_NAME}-artifacts/*.tar.gz
       env:
         TWINE_USERNAME: ${{ inputs.twine-username }}
         TWINE_PASSWORD: ${{ inputs.twine-token }}
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
         LIBRARY_NAME: ${{ inputs.library-name }}
-
+        SKIP_EXISTING_CMD: ${{ steps.skip-existing.outputs.SKIP_EXISTING_CMD }}

--- a/doc/source/changelog/884.fixed.md
+++ b/doc/source/changelog/884.fixed.md
@@ -1,0 +1,1 @@
+Missing skip-existing command handling


### PR DESCRIPTION
We are also missing the proper handling of the ``--skip-existing`` command. This requires a patch release as well