### PR TITLE
docs(prerelease): document installation by uv

### DIFF
--- a/doc/source/changelog/896.documentation.md
+++ b/doc/source/changelog/896.documentation.md
@@ -1,0 +1,1 @@
+Document installation by uv

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -27,12 +27,16 @@ Version ``v10``
   ``release-github``, and ``tests-pytest`` actions. This leverages `uv <https://docs.astral.sh/uv/>`_ for faster package installation,
   improving workflow speed for projects with multiple dependencies.
 
-  .. admonition:: About pre-releases
+  .. admonition:: About pre-releases and extra indices
 
       The installation of pre-releases by ``uv`` is only supported if these are
       listed in the ``pyproject.toml`` file. If you wish to install
       pre-releases at all levels, you must set the ``UV_PRERELEASE=allow``
       environment variable.
+
+      Regarding extra indices, ``uv`` supports the ``UV_EXTRA_INDEX_URL`` for
+      specifying extra indices. This is the equivalent to the
+      ``PIP_EXTRA_INDEX_URL`` environment variable.
 
 - **Dependency Groups Support:** ``doc-build`` and ``tests-pytest`` actions now support
   `PEP 735 <https://peps.python.org/pep-0735/>`_ dependency groups via the ``group-dependencies-name``

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -27,6 +27,13 @@ Version ``v10``
   ``release-github``, and ``tests-pytest`` actions. This leverages `uv <https://docs.astral.sh/uv/>`_ for faster package installation,
   improving workflow speed for projects with multiple dependencies.
 
+  .. admonition:: About pre-releases
+
+      The installation of pre-releases by ``uv`` is only supported if these are
+      listed in the ``pyproject.toml`` file. If you wish to install
+      pre-releases at all levels, you must set the ``UV_PRERELEASE=allow``
+      environment variable.
+
 - **Dependency Groups Support:** ``doc-build`` and ``tests-pytest`` actions now support
   `PEP 735 <https://peps.python.org/pep-0735/>`_ dependency groups via the ``group-dependencies-name``
   input. Extras remain supported through the ``optional-dependencies-name`` input.

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -27,11 +27,11 @@ Version ``v10``
   ``release-github``, and ``tests-pytest`` actions. This leverages `uv <https://docs.astral.sh/uv/>`_ for faster package installation,
   improving workflow speed for projects with multiple dependencies.
 
-  .. admonition:: About pre-releases
+  .. admonition:: About prereleases
 
-      The installation of pre-releases by ``uv`` is only supported if these are
+      The installation of prereleases by ``uv`` is only supported if these are
       listed in the ``pyproject.toml`` file. If you wish to install
-      pre-releases at all levels, you must set the ``UV_PRERELEASE=allow``
+      prereleases at all levels, you must set the ``UV_PRERELEASE=allow``
       environment variable.
 
 - **Dependency Groups Support:** ``doc-build`` and ``tests-pytest`` actions now support

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -27,11 +27,11 @@ Version ``v10``
   ``release-github``, and ``tests-pytest`` actions. This leverages `uv <https://docs.astral.sh/uv/>`_ for faster package installation,
   improving workflow speed for projects with multiple dependencies.
 
-  .. admonition:: About prereleases
+  .. admonition:: About pre-releases
 
-      The installation of prereleases by ``uv`` is only supported if these are
+      The installation of pre-releases by ``uv`` is only supported if these are
       listed in the ``pyproject.toml`` file. If you wish to install
-      prereleases at all levels, you must set the ``UV_PRERELEASE=allow``
+      pre-releases at all levels, you must set the ``UV_PRERELEASE=allow``
       environment variable.
 
 - **Dependency Groups Support:** ``doc-build`` and ``tests-pytest`` actions now support


### PR DESCRIPTION
Document the situation faced in #895 when installing pre-releases with `uv`.