### PR TITLE
fix(doc-build): wrong variable name for sphinx options

### DIFF
--- a/_doc-build-linux/action.yml
+++ b/_doc-build-linux/action.yml
@@ -389,11 +389,11 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        ${SPHINX_BUILD_MAKE} -C doc html SPHINXOPTS="${SPHINX_OPTS}"
+        ${SPHINX_BUILD_MAKE} -C doc html SPHINXOPTS="${SPHINXOPTS}"
         ${SPHINX_BUILD_MAKE} -C doc pdf
         if [[ "${CHECK_LINKS}" == 'true' ]];
         then
-          $SPHINX_BUILD_MAKE -C doc linkcheck SPHINXOPTS="${SPHINX_OPTS}"
+          $SPHINX_BUILD_MAKE -C doc linkcheck SPHINXOPTS="${SPHINXOPTS}"
         fi
 
     - name: "Build HTML and PDF documentation using xvfb"
@@ -405,11 +405,11 @@ runs:
       shell: bash
       run: |
         source .venv/bin/activate
-        xvfb-run ${SPHINX_BUILD_MAKE} -C doc html SPHINXOPTS="${SPHINX_OPTS}"
+        xvfb-run ${SPHINX_BUILD_MAKE} -C doc html SPHINXOPTS="${SPHINXOPTS}"
         xvfb-run ${SPHINX_BUILD_MAKE} -C doc pdf
         if [[ "${CHECK_LINKS}" == 'true' ]];
         then
-          xvfb-run $SPHINX_BUILD_MAKE -C doc linkcheck SPHINXOPTS="$SPHINX_OPTS"
+          xvfb-run $SPHINX_BUILD_MAKE -C doc linkcheck SPHINXOPTS="${SPHINXOPTS}"
         fi
 
     # ------------------------------------------------------------------------

--- a/doc/source/changelog/900.fixed.md
+++ b/doc/source/changelog/900.fixed.md
@@ -1,1 +1,1 @@
-Wrong variable name for sphinxopts
+Wrong variable name for sphinx options

--- a/doc/source/changelog/900.fixed.md
+++ b/doc/source/changelog/900.fixed.md
@@ -1,0 +1,1 @@
+Wrong variable name for sphinxopts


### PR DESCRIPTION
Fix #898 by using the right variable name when passing sphinx options at build time.