### PR TITLE
feat: improving error message for smoke tests

### DIFF
--- a/build-wheelhouse/smoke_test.py
+++ b/build-wheelhouse/smoke_test.py
@@ -75,13 +75,17 @@ def find_module_from_dist(pkg_name: str, attr: str):
     # Try to import each parent package and check for the desired attribute
     for path in candidate_paths:
         import_path = ".".join(path.parent.parts)
+        # Performing smoke test import
         try:
             mod = importlib.import_module(import_path)
             if hasattr(mod, attr):
                 return import_path, getattr(mod, attr)
-        except Exception:
-            continue
+        except Exception as e:
+            raise ImportError(
+                f"Smoke test failed for package '{pkg_name}' with error: {e}"
+            ) from e
 
+    # No module with the specified attribute was found in the package
     raise ImportError(
         f"Could not find a module in '{pkg_name}' with attribute '{attr}'"
     )

--- a/doc/source/changelog/908.added.md
+++ b/doc/source/changelog/908.added.md
@@ -1,0 +1,1 @@
+Improving error message for smoke tests


### PR DESCRIPTION
This PR will improve the error message when smoke tests are failing.

At the moment, the message only mentions ``Could not find a module in 'package_name' with attribute '__version__'`` even if the error comes from the library import. An example is visible with [pyansys-sound](https://github.com/ansys/pyansys-sound/actions/runs/15604481469/job/43950655238).