### PR TITLE
ci: Use dependabot cooldown for pip and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "pip"
     directories:
@@ -59,6 +58,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    cooldown:
+      default-days: 7
+      include:
+        - "*"  # Include all dependencies in cooldown
     commit-message:
       prefix: "build(actions)"
     labels:

--- a/doc/source/changelog/915.maintenance.md
+++ b/doc/source/changelog/915.maintenance.md
@@ -1,0 +1,1 @@
+Use dependabot cooldown for pip and gh actions

--- a/doc/source/changelog/915.maintenance.md
+++ b/doc/source/changelog/915.maintenance.md
@@ -1,1 +1,1 @@
-Use dependabot cooldown for pip and gh actions
+Use dependabot cooldown for pip and github actions


### PR DESCRIPTION
The cooldown feature is out of beta and should be working for github actions, see https://github.com/dependabot/dependabot-core/issues/3651#issuecomment-3006962980