### PR TITLE
docs: replace broken links with correct ones

### DIFF
--- a/check-environment-approval/action.yml
+++ b/check-environment-approval/action.yml
@@ -43,10 +43,10 @@ description: |
     `Github context <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context>`_
     to determine which environment to use. The manual approval can be added by
     referencing the
-    `Github environment <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#about-environments>`_
+    `Github environment <https://docs.github.com/en/actions/tutorials/deploying-with-github-actions#using-environments>`_
     in a workflow job and configuring the environment with deployment protection
     rules requiring a manual approval. For more information, see how to add
-    `required reviewers <https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#required-reviewers>`_.
+    `required reviewers <https://docs.github.com/en/actions/reference/deployments-and-environments#required-reviewers>`_.
 
 inputs:
 

--- a/doc/source/changelog/930.documentation.md
+++ b/doc/source/changelog/930.documentation.md
@@ -1,0 +1,1 @@
+Replace broken links with correct ones


### PR DESCRIPTION
Certain sections in GH's docs that were being pointed to no longer exist / have been moved to different locations. This is causing linkcheck failures e.g. in https://github.com/ansys/actions/actions/runs/16289420495/job/46072877288?pr=925 and https://github.com/ansys/actions/actions/runs/16370307355/job/46472413092?pr=929.
This PR fixes that.