### PR TITLE
Fix ``check-vulnerabilities`` action on Windows and projects using ``poetry``

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -413,6 +413,19 @@ runs:
           python -m pip install -r "${ACTION_PATH}/requirements.txt"
         fi
 
+    - name:  "Install wget on Windows"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        # Check if wget is installed - if not, install it
+        if (-not (Get-Command wget -ErrorAction SilentlyContinue)) {
+            Write-Host "wget is not installed. Installing using Chocolatey..."
+            # Install wget using Chocolatey
+            choco install wget -y
+        } else {
+            Write-Host "wget is already installed."
+        }
+
     - name: "Download the list of ignored safety vulnerabilities"
       shell: bash
       run: |

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -372,7 +372,7 @@ runs:
       run: |
         ${ACTIVATE_VENV}
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
-          poetry export --without-hashes --format=requirements.txt > requirements-for-safety.txt
+          poetry export --without-hashes --format=requirements.txt > "${ACTION_PATH}/requirements-for-safety.txt"
         elif [[ "${BUILD_BACKEND}" == 'uv' ]]; then
           uv pip freeze > "${ACTION_PATH}/requirements-for-safety.txt"
         else

--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -284,6 +284,7 @@ runs:
       run: |
         python -m pip install pipx
         python -m pipx install poetry
+        python -m pipx inject poetry poetry-plugin-export
       env:
         PIPX_BIN_DIR: ${{ runner.temp }}/pipx/bin
         PIPX_HOME : ${{ runner.temp }}/pipx/home


### PR DESCRIPTION
Following the issue reported in #941, a few fixes are suggested to the ``check-vulnerabilities`` action to ensure it works properly on Windows and for projects using ``poetry``:
* Add a step "Install wget on Windows" to install ``wget`` if missing just before the "Download the list of ignored safety vulnerabilities" step. This new step is the same as the one already implemented with the same name in the ``check-licenses`` action,
* Install ``poetry-plugin-export`` together with ``poetry`` in the "Install poetry and create a virtual environment" step. This change replicates what is implemented in the step of the same name in the ``build-wheelhouse`` action,
* Correct the path to the ``requirements-for-safety.txt`` for projects using ``poetry`` in the "Save installed packages" step to align with the commands used for other build backends.

These changes have been tested on the ``grantami-dataflow-extensions`` repo in the scope of this PR: https://github.com/ansys/grantami-dataflow-extensions/pull/146

Close #941 