### PR TITLE
fix: remove unnecessary tag and date from release notes

### DIFF
--- a/doc/source/changelog/948.fixed.md
+++ b/doc/source/changelog/948.fixed.md
@@ -1,0 +1,1 @@
+Remove unnecessary tag and date from release notes

--- a/python-utils/release_github_utils.py
+++ b/python-utils/release_github_utils.py
@@ -109,6 +109,10 @@ def get_tag_section(changelog_file: Path, body: str) -> str:
         else:
             print("Cannot generate release notes from changelog file.")
 
+    # Trimming first line to remove the tag and date since it is not needed for
+    # the github release notes
+    body = "\n".join(body.split("\n")[1:])
+
     return body
 
 


### PR DESCRIPTION
As the title.

See #946

Close #946