### PR TITLE
fix: ``check_vulnerabilities`` script for private repositories

### DIFF
--- a/check-vulnerabilities/check_vulnerabilities.py
+++ b/check-vulnerabilities/check_vulnerabilities.py
@@ -94,7 +94,8 @@ def check_vulnerabilities():
     existing_advisories = {}
     try:
         pl_advisories = repo.get_repository_advisories()
-    except github.GithubException.UnknownObjectException:
+        pl_advisories.totalCount
+    except Exception:
         # In case there is trouble accessing the repo
         pl_advisories = []
 


### PR DESCRIPTION
``check_vulnerabilities`` script was throwing an error when running it for a private repository, this PR fixes it.