### PR TITLE
ci: ensure manual approval on pr workflows

### DIFF
--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -40,9 +40,9 @@ jobs:
   # Dependabot PRs must be reviewed carefully and approved manually before
   # running the CI.
   check-dependabot-pr-flit:
-    needs: [check-environment-approval-flit]
     name: Manual approval (on dependabot PRs) flit
     runs-on: ubuntu-latest
+    needs: [check-environment-approval-flit]
     environment: ${{ needs.check-environment-approval-flit.outputs.environment }}
     steps:
       - name: Proceed after approval
@@ -130,6 +130,7 @@ jobs:
   test-build-wheelhouse-flit-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    needs: check-dependabot-pr-flit
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
@@ -173,6 +174,7 @@ jobs:
   test-build-library-flit-projects:
     name: "Test build-library action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: test-build-wheelhouse-flit-projects
     strategy:
       matrix:
         repository:
@@ -214,6 +216,7 @@ jobs:
   test-code-style-flit-projects:
     name: "Test code-style action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: check-dependabot-pr-flit
     strategy:
       matrix:
         repository:
@@ -248,6 +251,7 @@ jobs:
   test-doc-style-flit-projects:
     name: "Test doc-style action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: check-dependabot-pr-flit
     strategy:
       matrix:
         repository:

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -130,6 +130,7 @@ jobs:
   test-build-wheelhouse-poetry-projects:
     name: "Test build-wheelhouse action for ${{ matrix.repository.name }} project on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    needs: check-dependabot-pr-poetry
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
@@ -173,6 +174,7 @@ jobs:
   test-build-library-poetry-projects:
     name: "Test build-library action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: test-build-wheelhouse-poetry-projects
     strategy:
       matrix:
         repository:
@@ -214,6 +216,7 @@ jobs:
   test-code-style-poetry-projects:
     name: "Test code-style action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: check-dependabot-pr-poetry
     strategy:
       matrix:
         repository:
@@ -246,6 +249,7 @@ jobs:
   test-doc-style-poetry-projects:
     name: "Test doc-style action for ${{ matrix.repository.name }} project"
     runs-on: ubuntu-latest
+    needs: check-dependabot-pr-poetry
     strategy:
       matrix:
         repository:

--- a/doc/source/changelog/960.maintenance.md
+++ b/doc/source/changelog/960.maintenance.md
@@ -1,0 +1,1 @@
+Ensure manual approval on pr workflows


### PR DESCRIPTION
Some jobs were not prevented to run when a PR was opened by dependabot.
This PR ensures that manual approval is accepted for such cases.

Close #959 