### PR TITLE
refactor: `use-pull-request-title` instead of `use-conventional-commits`

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: ./doc-changelog
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          use-conventional-commits: true
+          use-pull-request-title: true
           use-default-towncrier-config: true
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc-changelog/action.yml
+++ b/doc-changelog/action.yml
@@ -91,7 +91,7 @@ inputs:
     default: true
     type: boolean
 
-  use-conventional-commits:
+  use-pull-request-title:
     description: |
       Use pull request title to determine the changelog category based on
       conventional commits. If ``false``, the labels in the pull request are used
@@ -99,6 +99,15 @@ inputs:
     required: false
     default: false
     type: boolean
+
+  use-conventional-commits: # TODO: Remove deprecated input in v11
+    description: |
+      [DEPRECATED] Use pull request title to determine the changelog category based on
+      conventional commits. If ``false``, the labels in the pull request are used
+      to determine the changelog category.
+    required: false
+    default: ''
+    type: string
 
   use-default-towncrier-config:
     description: |
@@ -136,6 +145,14 @@ runs:
           want to use a specific version of ``tomli``, please set the ``tomli-version``
           input accordingly. The ``toml-version`` input will be removed in v11.
 
+    - uses: ansys/actions/_logging@main
+      if: inputs.use-conventional-commits != ''
+      with:
+        level: "ERROR"
+        message: >
+          The ``use-conventional-commits`` input is deprecated and will be removed in v11.
+          Please use the ``use-pull-request-title`` input instead.
+
     - name: "Install Git and clone project"
       env:
         PR_BRANCH: ${{ github.event.pull_request.head.ref }}
@@ -163,7 +180,7 @@ runs:
         ${INSTALL_COMMAND} --upgrade pip towncrier==${TOWNCRIER_VERSION} tomli==${TOMLI_VERSION}
 
     - name: "Get first letter of conventional commit type"
-      if: ${{ inputs.use-conventional-commits == 'true' }}
+      if: ${{ inputs.use-pull-request-title == 'true' }}
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: python
@@ -178,20 +195,20 @@ runs:
         get_first_letter_case(pr_title)
 
     - name: "Check pull-request title follows conventional commits style"
-      if: ${{ (inputs.use-conventional-commits == 'true') && (env.FIRST_LETTER == 'lowercase') }}
+      if: ${{ (inputs.use-pull-request-title == 'true') && (env.FIRST_LETTER == 'lowercase') }}
       uses: ansys/actions/check-pr-title@main
       with:
         token: ${{ inputs.token }}
 
     - name: "Check pull-request title follows conventional commits style with upper case"
-      if: ${{ (inputs.use-conventional-commits == 'true') && (env.FIRST_LETTER == 'uppercase') }}
+      if: ${{ (inputs.use-pull-request-title == 'true') && (env.FIRST_LETTER == 'uppercase') }}
       uses: ansys/actions/check-pr-title@main
       with:
         token: ${{ inputs.token }}
         use-upper-case: true
 
     - name: "Get conventional commit type from title"
-      if: ${{ inputs.use-conventional-commits == 'true' }}
+      if: ${{ inputs.use-pull-request-title == 'true' }}
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
       shell: python
@@ -207,7 +224,7 @@ runs:
 
     - name: "Get labels in the pull request"
       id: get-labels
-      if: ${{ inputs.use-conventional-commits == 'false' }}
+      if: ${{ inputs.use-pull-request-title == 'false' }}
       env:
         GH_TOKEN: ${{ inputs.token }}
         REPO_NAME: ${{ github.event.repository.name }}
@@ -221,7 +238,7 @@ runs:
         echo LABELS='"'$pr_labels'"' >> ${GITHUB_OUTPUT}
 
     - name: "Set CHANGELOG category based on conventional commit type"
-      if: ${{ inputs.use-conventional-commits == 'true' }}
+      if: ${{ inputs.use-pull-request-title == 'true' }}
       shell: python
       run: |
         import sys
@@ -233,7 +250,7 @@ runs:
         changelog_category_cc(cc_type)
 
     - name: "Set PR label environment variable"
-      if: ${{ inputs.use-conventional-commits == 'false' }}
+      if: ${{ inputs.use-pull-request-title == 'false' }}
       shell: python
       env:
         LABELS: ${{ steps.get-labels.outputs.LABELS }}
@@ -263,7 +280,7 @@ runs:
     - name: "Clean PR title"
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
-        USE_CONVENTIONAL_COMMITS: ${{ inputs.use-conventional-commits }}
+        USE_CONVENTIONAL_COMMITS: ${{ inputs.use-pull-request-title }}
       shell: python
       run: |
         import os

--- a/doc/source/doc-actions/examples/doc-changelog-basic.yml
+++ b/doc/source/doc-actions/examples/doc-changelog-basic.yml
@@ -23,6 +23,6 @@ changelog-fragment:
         bot-user: ${{ '{{ secrets.PYANSYS_CI_BOT_USERNAME }}' }}
         bot-email: ${{ '{{ secrets.PYANSYS_CI_BOT_EMAIL }}' }}
         # uncomment this line to use conventional commits instead of labels
-        # use-conventional-commits: true
+        # use-pull-request-title: true
         # uncomment this if you don't have any towncrier configuration in your pyproject.toml file
         # use-default-towncrier-config: true


### PR DESCRIPTION
To be merged after #961