### PR TITLE
build: temporary pin `typer` dependency (transitive)

### DIFF
--- a/check-vulnerabilities/requirements.txt
+++ b/check-vulnerabilities/requirements.txt
@@ -2,3 +2,4 @@ bandit>=1.7,<2
 click>=7.0,<9
 pygithub>=1.59,<3
 safety>=2.3,<4
+typer>=0.16,<0.17 # Temporary pin transitive dependency, see https://github.com/ansys/actions/issues/970

--- a/doc/source/changelog/971.dependencies.md
+++ b/doc/source/changelog/971.dependencies.md
@@ -1,0 +1,1 @@
+Temporary pin typer dependency (transitive)

--- a/doc/source/changelog/971.dependencies.md
+++ b/doc/source/changelog/971.dependencies.md
@@ -1,1 +1,1 @@
-Temporary pin typer dependency (transitive)
+Temporary pin `typer` dependency (transitive)


### PR DESCRIPTION
As title says. Might not be needed if https://github.com/pyupio/safety/pull/779 get merged quickly

Close #970 