### PR TITLE
build: typer package causing breaking changes on safety

### DIFF
--- a/check-vulnerabilities/requirements.txt
+++ b/check-vulnerabilities/requirements.txt
@@ -2,3 +2,4 @@ bandit>=1.7,<2
 click>=7.0,<9
 pygithub>=1.59,<3
 safety>=2.3,<4
+typer<0.17

--- a/doc/source/changelog/972.dependencies.md
+++ b/doc/source/changelog/972.dependencies.md
@@ -1,0 +1,1 @@
+Typer package causing breaking changes on safety


### PR DESCRIPTION
See https://github.com/ansys/ansys-tools-visualization-interface/actions/runs/17366739733/job/49294788127?pr=342 as an example

Safety hasn't updated its requirements yet - I will keep an eye out but in the meantime we should limit the `typer` package version. Release 0.17 went out just a few days ago. https://github.com/fastapi/typer/releases

> [!IMPORTANT]
> This requires a patch release of our actions.