### PR TITLE
chore: remove transient dependency pin

### DIFF
--- a/check-vulnerabilities/requirements.txt
+++ b/check-vulnerabilities/requirements.txt
@@ -2,4 +2,3 @@ bandit>=1.7,<2
 click>=7.0,<9
 pygithub>=1.59,<3
 safety>=2.3,<4
-typer>=0.16,<0.17 # Temporary pin transitive dependency, see https://github.com/ansys/actions/issues/970


### PR DESCRIPTION
Seems like `safety`'s maintainers have performed a new release [v3.6.1](https://github.com/pyupio/safety/releases/tag/3.6.1)with `typer` required changes. This PR reverts the temporary fix #971.