### PR TITLE
fix: Pin twine to <6.2.0 and bump pypa action

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -98,7 +98,7 @@ jobs:
         path: dist
 
     - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: "https://test.pypi.org/legacy/"
         print-hash: true

--- a/.github/workflows/ci_cd_pr_flit.yml
+++ b/.github/workflows/ci_cd_pr_flit.yml
@@ -120,7 +120,7 @@ jobs:
         path: dist
 
     - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: "https://test.pypi.org/legacy/"
         print-hash: true

--- a/.github/workflows/ci_cd_pr_poetry.yml
+++ b/.github/workflows/ci_cd_pr_poetry.yml
@@ -120,7 +120,7 @@ jobs:
         path: dist
 
     - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: "https://test.pypi.org/legacy/"
         print-hash: true

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -238,7 +238,7 @@ jobs:
       run: ls -R
 
     - name: "Upload artifacts to test PyPI using trusted publisher"
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         repository-url: "https://test.pypi.org/legacy/"
         print-hash: true

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -140,7 +140,7 @@ runs:
       env:
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        ${INSTALL_COMMAND} --upgrade pip twine
+        ${INSTALL_COMMAND} --upgrade pip twine==6.1.0
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -140,7 +140,7 @@ runs:
       env:
         INSTALL_COMMAND: ${{ inputs.use-uv == 'true' && 'uv pip install --no-managed-python --system' || 'python -m pip install' }}
       run: |
-        ${INSTALL_COMMAND} --upgrade pip twine==6.1.0
+        ${INSTALL_COMMAND} --upgrade pip twine<6.2.0
 
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/doc/source/changelog/983.fixed.md
+++ b/doc/source/changelog/983.fixed.md
@@ -1,1 +1,1 @@
-Pin twine to 6.1.0
+Pin twine to <6.2.0 and bump pypa action

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -7,6 +7,7 @@ dependabot
 dev
 dependabot
 GitHub
+pypa
 pytest
 PyPI
 SBOM


### PR DESCRIPTION
Pin twine to v6.1.0 until we adjust the code to work for v6.2.0