### PR TITLE
test: add more pre-release tests

### DIFF
--- a/doc/source/changelog/986.miscellaneous.md
+++ b/doc/source/changelog/986.miscellaneous.md
@@ -1,0 +1,1 @@
+Pre release support

--- a/doc/source/changelog/986.miscellaneous.md
+++ b/doc/source/changelog/986.miscellaneous.md
@@ -1,1 +1,1 @@
-Pre release support
+Pre-release support

--- a/doc/source/changelog/986.miscellaneous.md
+++ b/doc/source/changelog/986.miscellaneous.md
@@ -1,1 +1,0 @@
-Improve pre-release support

--- a/doc/source/changelog/986.miscellaneous.md
+++ b/doc/source/changelog/986.miscellaneous.md
@@ -1,1 +1,1 @@
-Pre-release support
+Improve pre-release support

--- a/doc/source/changelog/986.test.md
+++ b/doc/source/changelog/986.test.md
@@ -1,0 +1,1 @@
+Add more pre-release tests

--- a/python-utils/test_versions.py
+++ b/python-utils/test_versions.py
@@ -238,7 +238,7 @@ BASE_NORMAL_RELEASE_DATA = [
         "ref_name": "v0.10.10",
         "independent_patch_release": "false",
         "versions": ["0.7", "0.8", "0.9", "0.10", "0.11.0a0", "0.11.0b0"],
-    }
+    },
 ]
 
 BASE_DATA = deepcopy(BASE_PRERELEASE_DATA) + deepcopy(BASE_NORMAL_RELEASE_DATA)
@@ -430,7 +430,10 @@ SPECIAL_TEST_DATA_THREE = [
     }
 ]
 
-@pytest.mark.parametrize("test_environment_setup", SPECIAL_TEST_DATA_THREE, indirect=True)
+
+@pytest.mark.parametrize(
+    "test_environment_setup", SPECIAL_TEST_DATA_THREE, indirect=True
+)
 def test_prerelease_versions_persist_during_older_release_patch(test_environment_setup):
     set_version_variable()
     remaining_versions = get_versions_list()
@@ -442,6 +445,7 @@ def test_prerelease_versions_persist_during_older_release_patch(test_environment
     remaining_versions.sort()
     expected_result.sort()
     assert remaining_versions == expected_result
+
 
 SPECIAL_TEST_DATA_FOUR = [
     {
@@ -467,4 +471,3 @@ def test_maximum_three_prerelease(test_environment_setup):
     ]
 
     assert len(prerelease_versions) == 2
-

--- a/python-utils/test_versions.py
+++ b/python-utils/test_versions.py
@@ -232,6 +232,13 @@ BASE_NORMAL_RELEASE_DATA = [
         "independent_patch_release": "false",
         "versions": ["0.1", "0.2", "0.5", "1.0", "1.5"],
     },
+    # Data involving patching an older release
+    {
+        "ref_type": "tag",
+        "ref_name": "v0.10.10",
+        "independent_patch_release": "false",
+        "versions": ["0.7", "0.8", "0.9", "0.10", "0.11.0a0", "0.11.0b0"],
+    }
 ]
 
 BASE_DATA = deepcopy(BASE_PRERELEASE_DATA) + deepcopy(BASE_NORMAL_RELEASE_DATA)
@@ -415,6 +422,30 @@ def test_prerelease_versions_clear_during_normal_release(test_environment_setup)
 SPECIAL_TEST_DATA_THREE = [
     {
         "ref_type": "tag",
+        "ref_name": "v0.10.10",
+        "independent_patch_release": "false",
+        "versions": ["0.7", "0.8", "0.9", "0.10", "0.11.0a0", "0.11.0b0"],
+        "create_versions_directories": True,
+        "create_github_output_file": True,
+    }
+]
+
+@pytest.mark.parametrize("test_environment_setup", SPECIAL_TEST_DATA_THREE, indirect=True)
+def test_prerelease_versions_persist_during_older_release_patch(test_environment_setup):
+    set_version_variable()
+    remaining_versions = get_versions_list()
+
+    test_data = test_environment_setup
+    versions = test_data["versions"]
+    expected_result = [Version(version) for version in versions]
+
+    remaining_versions.sort()
+    expected_result.sort()
+    assert remaining_versions == expected_result
+
+SPECIAL_TEST_DATA_FOUR = [
+    {
+        "ref_type": "tag",
         "ref_name": "v0.4.0rc1",
         "independent_patch_release": "true",
         "versions": ["0.1", "0.2", "0.3", "0.4.0b1", "0.4.0b2", "0.4.0rc0"],
@@ -425,7 +456,7 @@ SPECIAL_TEST_DATA_THREE = [
 
 
 @pytest.mark.parametrize(
-    "test_environment_setup", SPECIAL_TEST_DATA_THREE, indirect=True
+    "test_environment_setup", SPECIAL_TEST_DATA_FOUR, indirect=True
 )
 def test_maximum_three_prerelease(test_environment_setup):
     set_version_variable()
@@ -436,3 +467,4 @@ def test_maximum_three_prerelease(test_environment_setup):
     ]
 
     assert len(prerelease_versions) == 2
+

--- a/python-utils/versions.py
+++ b/python-utils/versions.py
@@ -211,10 +211,15 @@ def set_version_variable() -> None:
                 )
                 exit(1)
         else:
-            # All existing pre-releases must be removed before the normal release
+            # All existing pre-releases must be removed before the normal release.
+            # But if the normal release is lower than the pre-releases, this step
+            # should be skipped (for example, a project wants to patch a previous
+            # normal release).
             for prerel in existing_prereleases:
-                prerel_path = Path(f"version/{prerel}")
-                shutil.rmtree(prerel_path)
+                if current_version > prerel:
+                    prerel_path = Path(f"version/{prerel}")
+                    shutil.rmtree(prerel_path)
+
             if independent_patch_release:
                 export_to_github_output("VERSION", str(current_version))
                 export_to_github_output("PRE_RELEASE", "false")

--- a/python-utils/versions.py
+++ b/python-utils/versions.py
@@ -212,13 +212,9 @@ def set_version_variable() -> None:
                 exit(1)
         else:
             # All existing pre-releases must be removed before the normal release.
-            # But if the normal release is lower than the pre-releases, this step
-            # should be skipped (for example, a project wants to patch a previous
-            # normal release).
             for prerel in existing_prereleases:
-                if current_version > prerel:
-                    prerel_path = Path(f"version/{prerel}")
-                    shutil.rmtree(prerel_path)
+                prerel_path = Path(f"version/{prerel}")
+                shutil.rmtree(prerel_path)
 
             if independent_patch_release:
                 export_to_github_output("VERSION", str(current_version))


### PR DESCRIPTION
Imagine this scenario:
 - A project has made `v0.11.0a0` and `v0.11.0b0` pre-releases.
 - Then proceeds to patch `v0.10` for whatever reason.

The current logic will remove deployed documentation for the pre-releases and this shouldn't be the case. This PR fixes that.