### PR TITLE
fix: GitHub command-line tool command in ansys/release-github

### DIFF
--- a/doc/source/changelog/1012.fixed.md
+++ b/doc/source/changelog/1012.fixed.md
@@ -1,1 +1,1 @@
-GitHub CLI command in ansys/release-github
+GitHub command-line tool command in ansys/release-github

--- a/doc/source/changelog/1012.fixed.md
+++ b/doc/source/changelog/1012.fixed.md
@@ -1,0 +1,1 @@
+GitHub CLI command in ansys/release-github

--- a/release-github/action.yml
+++ b/release-github/action.yml
@@ -396,7 +396,8 @@ runs:
 
           # Find the following artifacts: wheels, source distribution, wheelhouse and SBOM files
           for artifact in $(find dist -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*wheelhouse*.zip" -o -name "*sbom.spdx" \)); do
-            echo "\$ gh attestation verify --owner ${GITHUB_REPOSITORY_OWNER} ${artifact}"
+            filename=$(basename "$artifact")
+            echo "\$ gh attestation verify --owner ${GITHUB_REPOSITORY_OWNER} ${filename}"
           done
 
           echo "\`\`\`"


### PR DESCRIPTION
Use base name instead of the relative path to the file.

Close #1011 