### PR TITLE
docs: Fix typo in ``vulnerability-actions/index.rst``

### DIFF
--- a/doc/source/changelog/1030.documentation.md
+++ b/doc/source/changelog/1030.documentation.md
@@ -1,0 +1,1 @@
+Fix typo in \`\`vulnerability-actions/index.rst\`\`

--- a/doc/source/vulnerability-actions/index.rst
+++ b/doc/source/vulnerability-actions/index.rst
@@ -88,7 +88,7 @@ Check actions security action
                         ansys/*: hash-pin
                         actions/*: hash-pin
 
-   #. Run ``zizmor --persona=pedantic .`` for a minimal audit (action's default) or ``zizmor --persona=auditor`` for a stricter audit.
+   #. Run ``zizmor --persona=pedantic .`` for a minimal audit (action's default) or ``zizmor --persona=auditor .`` for a stricter audit.
    #. To generate a summary table locally:
 
       - Download the ``zizmor-summary.py`` file from the


### PR DESCRIPTION
Fixing a minor typo I encountered in the file ``vulnerability-actions/index.rst``.