### PR TITLE
fix(code-style): use uv sync if lock file is present

### DIFF
--- a/check-vulnerabilities/action.yml
+++ b/check-vulnerabilities/action.yml
@@ -377,7 +377,11 @@ runs:
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
           poetry install --extras "${extra_targets}"
         elif [[ "${BUILD_BACKEND}" == 'uv' ]]; then
-          uv pip install ."${extra_targets}"
+          if [ -f "uv.lock" ]; then
+            uv sync --extra "${extra_targets}"
+          else
+            uv pip install ."${extra_targets}"
+          fi
         else
           python -m pip install ."${extra_targets}"
         fi

--- a/code-style/action.yml
+++ b/code-style/action.yml
@@ -250,7 +250,11 @@ runs:
         if [[ "${BUILD_BACKEND}" == 'poetry' ]]; then
           poetry install
         elif [[ "${BUILD_BACKEND}" == 'uv' ]]; then
-          uv pip install .
+          if [ -f "uv.lock" ]; then
+            uv sync
+          else
+            uv pip install .
+          fi
         else
           python -m pip install .
         fi

--- a/doc/source/changelog/1088.fixed.md
+++ b/doc/source/changelog/1088.fixed.md
@@ -1,0 +1,1 @@
+Use uv sync if lock file is present


### PR DESCRIPTION
Fix #926 by using `uv pip install` or `uv sync` depending on whether a `uv.lock` file is present.