### PR TITLE
fix: Make version check optional for private pypi publish

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -81,6 +81,13 @@ inputs:
     required: true
     type: boolean
 
+  verify-tag-version:
+    description: |
+      Verify that the git ref that triggered the workflow is the same as the version
+      of the package being uploaded.
+    required: true
+    type: boolean
+
   use-trusted-publisher:
     description: |
       Whether to use the OIDC token for releasing.
@@ -151,6 +158,7 @@ runs:
 
     - name: "Verify tag and artifacts version match"
       shell: bash
+      if: ${{ inputs.verify-tag-version == 'true' }}
       env:
         ARTIFACT_DIR: ${{ inputs.library-name }}-artifacts
       run: |

--- a/doc/source/changelog/1500.fixed.md
+++ b/doc/source/changelog/1500.fixed.md
@@ -1,0 +1,1 @@
+Make version check optional for private pypi publish

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -114,6 +114,14 @@ inputs:
     default: "https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload"
     type: string
 
+  verify-tag-version:
+    description: |
+      Verify that the git ref that triggered the workflow is the same as the version
+      of the package being uploaded.
+    required: false
+    default: true
+    type: boolean
+
 runs:
   using: "composite"
   steps:
@@ -129,3 +137,4 @@ runs:
         dry-run: ${{ inputs.dry-run }}
         skip-existing: ${{ inputs.skip-existing }}
         use-trusted-publisher: ${{ inputs.use-trusted-publisher }}
+        verify-tag-version: ${{ inputs.verify-tag-version }}


### PR DESCRIPTION
Addresses #1499 

Makes the verification step optional for private pypi publish, the inner action has a required `verify-tag-version` input. The outer action has an optional input with the same name which defaults ot true.