### PR TITLE
docs: document multiple-file Vale input for doc-style

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -166,9 +166,26 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: "Collect files for Vale as JSON"
+        id: collect-vale-files
+        shell: bash
+        run: |
+          python - <<'PY' >> "${GITHUB_OUTPUT}"
+          import json
+          from pathlib import Path
+
+          files = sorted(
+              str(path)
+              for path in Path("doc/source").rglob("*.rst")
+              if not path.is_relative_to("doc/source/api")
+          )
+          print(f"vale_files={json.dumps(files)}")
+          PY
+
       - uses: ./doc-style
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.collect-vale-files.outputs.vale_files }}
           checkout: false
 
   doc-build:

--- a/doc-style/action.yml
+++ b/doc-style/action.yml
@@ -48,7 +48,10 @@ inputs:
 
   files:
     description: |
-      Path to the directory containing the documentation files.
+      Path to the documentation files to check. You can pass a directory path
+      (for example ``doc``) or a JSON-formatted array of file paths
+      (for example ``["doc/source/index.rst", "doc/source/getting-started.rst"]``)
+      to lint multiple explicit files.
     default: 'doc'
     required: false
     type: string

--- a/doc/source/changelog/1501.documentation.md
+++ b/doc/source/changelog/1501.documentation.md
@@ -1,0 +1,1 @@
+Document multiple-file Vale input for doc-style

--- a/doc/source/style-actions/examples/doc-style-multiple-files.yml
+++ b/doc/source/style-actions/examples/doc-style-multiple-files.yml
@@ -5,19 +5,23 @@ doc-style:
     contents: read
     pull-requests: write
   steps:
+    - name: "Install Git and clone project"
+      uses: actions/checkout@v6
+
     - name: "Install jq"
       run: |
         # Used to format Vale input as a JSON-formatted list of files
         sudo apt install -y jq
 
     - name: "Collect files for Vale"
+      id: collect-files
       run: |
         RST_FILES=$(find doc/source -type f -name "*.rst" ! -path "doc/source/api/*")
         VALE_FILES=$(echo -e "$RST_FILES" | jq -R . | jq -s .)
-        echo "VALE_FILES=$(echo "$VALE_FILES")" >> "$GITHUB_ENV"
+        echo "VALE_FILES=$(echo "$VALE_FILES")" >> "${GITHUB_OUTPUT}"
 
     - name: "Running documentation style checks"
       uses: ansys/actions/doc-style@{{ version }}
       with:
         token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
-        files: ${{ '{{ env.VALE_FILES }}' }}
+        files: ${{ '{{ steps.collect-files.outputs.VALE_FILES }}' }}

--- a/doc/source/style-actions/examples/doc-style-multiple-files.yml
+++ b/doc/source/style-actions/examples/doc-style-multiple-files.yml
@@ -14,11 +14,20 @@ doc-style:
         sudo apt install -y jq
 
     - name: "Collect files for Vale"
-      id: collect-files
-      run: |
-        RST_FILES=$(find doc/source -type f -name "*.rst" ! -path "doc/source/api/*")
-        VALE_FILES=$(echo -e "$RST_FILES" | jq -R . | jq -s .)
-        echo "VALE_FILES=$(echo "$VALE_FILES")" >> "${GITHUB_OUTPUT}"
+        id: collect-files
+        shell: bash
+        run: |
+          python - <<'PY' >> "${GITHUB_OUTPUT}"
+          import json
+          from pathlib import Path
+
+          files = sorted(
+              str(path)
+              for path in Path("doc/source").rglob("*.rst")
+              if not path.is_relative_to("doc/source/api")
+          )
+          print(f"VALE_FILES={json.dumps(files)}")
+          PY
 
     - name: "Running documentation style checks"
       uses: ansys/actions/doc-style@{{ version }}

--- a/doc/source/style-actions/examples/doc-style-multiple-files.yml
+++ b/doc/source/style-actions/examples/doc-style-multiple-files.yml
@@ -1,0 +1,23 @@
+doc-style:
+  name: "Running documentation style checks on multiple files"
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+    pull-requests: write
+  steps:
+    - name: "Install jq"
+      run: |
+        # Used to format Vale input as a JSON-formatted list of files
+        sudo apt install -y jq
+
+    - name: "Collect files for Vale"
+      run: |
+        RST_FILES=$(find doc/source -type f -name "*.rst" ! -path "doc/source/api/*")
+        VALE_FILES=$(echo -e "$RST_FILES" | jq -R . | jq -s .)
+        echo "VALE_FILES=$(echo "$VALE_FILES")" >> "$GITHUB_ENV"
+
+    - name: "Running documentation style checks"
+      uses: ansys/actions/doc-style@{{ version }}
+      with:
+        token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
+        files: ${{ '{{ env.VALE_FILES }}' }}

--- a/doc/source/style-actions/examples/doc-style-multiple-files.yml
+++ b/doc/source/style-actions/examples/doc-style-multiple-files.yml
@@ -14,20 +14,20 @@ doc-style:
         sudo apt install -y jq
 
     - name: "Collect files for Vale"
-        id: collect-files
-        shell: bash
-        run: |
-          python - <<'PY' >> "${GITHUB_OUTPUT}"
-          import json
-          from pathlib import Path
+      id: collect-files
+      shell: bash
+      run: |
+        python - <<'PY' >> "${GITHUB_OUTPUT}"
+        import json
+        from pathlib import Path
 
-          files = sorted(
-              str(path)
-              for path in Path("doc/source").rglob("*.rst")
-              if not path.is_relative_to("doc/source/api")
-          )
-          print(f"VALE_FILES={json.dumps(files)}")
-          PY
+        files = sorted(
+            str(path)
+            for path in Path("doc/source").rglob("*.rst")
+            if not path.is_relative_to("doc/source/api")
+        )
+        print(f"VALE_FILES={json.dumps(files)}")
+        PY
 
     - name: "Running documentation style checks"
       uses: ansys/actions/doc-style@{{ version }}


### PR DESCRIPTION
This updates the `doc-style` action docs to show how to lint an explicit list of files with Vale.

- Clarifies that the `files` input accepts either a directory path or a JSON-formatted array of file paths.
- Adds a `doc-style-multiple-files.yml` example that builds a JSON file list with `jq` and passes it through `env.VALE_FILES`.

Closes #730.
