### PR TITLE
fix: build-library for projects not using uv lockfiles

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -222,9 +222,9 @@ runs:
       env:
         TAG_REF: ${{ github.ref_name }}
         LIBRARY_NAME: ${{ inputs.library-name }}
-        USE_UV: ${{ inputs.use-uv }}
+        USE_UV_LOCKFILE: ${{ steps.auto-detect-uv-lockfile.outputs.USE_UV_LOCKFILE }}
       run: |
-        if [[ "${USE_UV}" == 'true' ]]; then
+        if [[ "${USE_UV_LOCKFILE}" == 'true' ]]; then
           LIBRARY_VERSION=$(uv run python -c "import importlib.metadata as importlib_metadata; print(importlib_metadata.version('$LIBRARY_NAME'))")
         else
           LIBRARY_VERSION=$(python -c "import importlib.metadata as importlib_metadata; print(importlib_metadata.version('$LIBRARY_NAME'))")

--- a/doc/source/changelog/1503.fixed.md
+++ b/doc/source/changelog/1503.fixed.md
@@ -1,0 +1,1 @@
+Build-library for projects not using uv lockfiles


### PR DESCRIPTION
The changes we made in #1487 has the unforeseen side-effect that `uv run ...` only works with virtual environments.

So for projects not using uv lockfiles but still leveraging `use-uv`, `uv run ...` will create a fresh venv, leading to an error since the library will not be available in this new venv. See [this example](https://github.com/ansys-internal/ansys-turbo-components/actions/runs/32879390493/job/97910350539).

Thanks to @Acohen-work for reporting this.