### PR TITLE
docs: update vulnerability documentation on safety local scanning

### DIFF
--- a/doc/source/changelog/1512.documentation.md
+++ b/doc/source/changelog/1512.documentation.md
@@ -1,0 +1,1 @@
+Update vulnerability documentation on safety local scanning

--- a/doc/source/vulnerability-actions/index.rst
+++ b/doc/source/vulnerability-actions/index.rst
@@ -76,7 +76,7 @@ Check vulnerabilities action
            export REQUESTS_CA_BUNDLE=~/combined-ca.pem
 
       - ``safety`` 3.8.0 and later use ``httpx`` instead of ``requests`` (see the
-        `safety changelog <https://github.com/pyupio/safety/blob/main/CHANGELOG.md#380b0-2025-12-02>`_),
+        `safety changelog <https://github.com/pyupio/safety/blob/main/CHANGELOG.md>`_),
         which ignores ``REQUESTS_CA_BUNDLE`` entirely and only reads
         ``SSL_CERT_FILE`` (or ``SSL_CERT_DIR``):
 

--- a/doc/source/vulnerability-actions/index.rst
+++ b/doc/source/vulnerability-actions/index.rst
@@ -51,12 +51,12 @@ Check vulnerabilities action
       - ``DEPENDENCY_CHECK_REPOSITORY``: The full name of the repository you are interested in. This is the name of the repository in the format ``<owner>/<repository>``.
 
    #. On **corporate networks with SSL inspection**, connections to external HTTPS
-      endpoints is going to fail with an SSL certificate verification error because the
-      ``requests`` library `uses certifi's CA bundle
+      endpoints is going to fail with an SSL certificate verification error because
+      the underlying HTTP libraries `use certifi's CA bundle
       <https://requests.readthedocs.io/en/latest/user/advanced/#ca-certificates>`_
-      and does not trust the corporate CA by default. Build a combined CA bundle
+      and do not trust the corporate CA by default. Build a combined CA bundle
       that includes both your corporate root CA and the standard ``certifi``
-      bundle, then point ``REQUESTS_CA_BUNDLE`` to it:
+      bundle:
 
       .. code-block:: bash
 
@@ -64,14 +64,48 @@ Check vulnerabilities action
          # then combine it with certifi's public CA bundle:
          CA_BUNDLE=$(python -c "import certifi; print(certifi.where())")
          cat "$CA_BUNDLE" /path/to/corporate-ca.pem > ~/combined-ca.pem
-         export REQUESTS_CA_BUNDLE=~/combined-ca.pem
+
+      Which environment variable to point at this combined bundle depends on the
+      HTTP library used:
+
+      - ``check_vulnerabilities.py`` itself and ``PyGithub`` use the ``requests``
+        library, which only reads ``REQUESTS_CA_BUNDLE``:
+
+        .. code-block:: bash
+
+           export REQUESTS_CA_BUNDLE=~/combined-ca.pem
+
+      - ``safety`` 3.8.0 and later use ``httpx`` instead of ``requests`` (see the
+        `safety changelog <https://github.com/pyupio/safety/blob/main/CHANGELOG.md#380b0-2025-12-02>`_),
+        which ignores ``REQUESTS_CA_BUNDLE`` entirely and only reads
+        ``SSL_CERT_FILE`` (or ``SSL_CERT_DIR``):
+
+        .. code-block:: bash
+
+           export SSL_CERT_FILE=~/combined-ca.pem
+
+        If you are using ``safety`` older than 3.8.0, it still relies on
+        ``requests``, so ``REQUESTS_CA_BUNDLE`` alone is sufficient and
+        ``SSL_CERT_FILE`` is not required.
+
+      To cover both cases regardless of the installed ``safety`` version, export
+      both variables to point at the same combined bundle.
 
       .. note::
 
-         Setting ``REQUESTS_CA_BUNDLE`` to the corporate CA file alone is not
-         sufficient: it replaces ``certifi``'s bundle entirely, so public CAs
-         (DigiCert, etc.) are no longer trusted. The combined bundle is required
-         when the corporate proxy does not intercept all domains.
+         Setting ``REQUESTS_CA_BUNDLE`` or ``SSL_CERT_FILE`` to the corporate CA
+         file alone is not sufficient: it replaces ``certifi``'s bundle entirely,
+         so public CAs (DigiCert, etc.) are no longer trusted. The combined
+         bundle is required when the corporate proxy does not intercept all
+         domains.
+
+      .. note::
+
+         If ``safety check`` still fails with a ``certificate verify failed:
+         unable to get local issuer certificate`` error after setting
+         ``REQUESTS_CA_BUNDLE``, check your installed ``safety`` version
+         (``safety --version``) and set ``SSL_CERT_FILE`` as well, since 3.8.0+
+         does not honor ``REQUESTS_CA_BUNDLE``.
 
       .. note::
 


### PR DESCRIPTION
I recently had to do local scanning in `pydpf-core` and discovered that `safety` dropped `requests` for `httpx`. The implication is that the documentation on local scanning with safety needs to be updated wrt the environment variables that need to be set, hence this PR.