### PR TITLE
ci: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,7 @@ updates:
       cicd-actions:
         patterns:
           - "micnncim/action-label-syncer"
+          - "pypa/gh-action-pypi-publish"
       # Github actions that are used in our composite actions
       github-actions:
         patterns:
@@ -104,15 +105,14 @@ updates:
       # Actions associated to our release composite actions
       release-related-actions:
         patterns:
-          - "pypa/gh-action-pypi-publish"
           - "softprops/action-gh-release"
       # Missed non ansys actions that should by assigned to a group
       must-be-assigned-actions:
         patterns:
-          - peter-evans/find-comment
-          - pyvista/setup-headless-display-action
-          - vimtor/action-zip
-          - dependabot/fetch-metadata
+          - "peter-evans/find-comment"
+          - "pyvista/setup-headless-display-action"
+          - "vimtor/action-zip"
+          - "dependabot/fetch-metadata"
         exclude-patterns:
           - "ansys/actions*"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,7 @@ updates:
         patterns:
           - "micnncim/action-label-syncer"
           - "pypa/gh-action-pypi-publish"
+          - "pyvista/setup-headless-display-action"
       # Github actions that are used in our composite actions
       github-actions:
         patterns:
@@ -110,7 +111,6 @@ updates:
       must-be-assigned-actions:
         patterns:
           - "peter-evans/find-comment"
-          - "pyvista/setup-headless-display-action"
           - "vimtor/action-zip"
           - "dependabot/fetch-metadata"
         exclude-patterns:

--- a/doc/source/changelog/1516.maintenance.md
+++ b/doc/source/changelog/1516.maintenance.md
@@ -1,0 +1,1 @@
+Update dependabot configuration


### PR DESCRIPTION
Tiny update of the dependabot configuration because `pypa/gh-action-pypi-publish` is no longer an action that we leverage in any of our actions (see https://github.com/ansys/actions/pull/758 for more information). Now, it is only used in our CI.
Other minor changes are performed.