### PR TITLE
chore: remove `skip-existing` input for release-pypi-private

### DIFF
--- a/_release-pypi/action.yml
+++ b/_release-pypi/action.yml
@@ -74,13 +74,6 @@ inputs:
     required: true
     type: boolean
 
-  skip-existing:
-    description: |
-      Continue uploading files if one already exists. Only valid when uploading
-      to PyPI. Other implementations may not support this.
-    required: true
-    type: boolean
-
   verify-tag-version:
     description: |
       Verify that the git ref that triggered the workflow is the same as the version
@@ -207,27 +200,14 @@ runs:
       shell: bash
       run: ls -R
 
-    - name: "Evaluate if skip-existing is required"
-      shell: bash
-      id: skip-existing
-      env:
-        SKIP_EXISTING: ${{ inputs.skip-existing }}
-      run: |
-        if [[ "${SKIP_EXISTING}" == 'true' ]]; then
-          echo "SKIP_EXISTING_CMD=--skip-existing" >> ${GITHUB_OUTPUT}
-        else
-          echo "SKIP_EXISTING_CMD=''" >> ${GITHUB_OUTPUT}
-        fi
-
     - name: "Upload artifacts to PyPi"
       shell: bash
       if: inputs.dry-run == 'false' && inputs.use-trusted-publisher == 'false'
       run: |
-        python -m twine upload --verbose ${SKIP_EXISTING_CMD} ${LIBRARY_NAME}-artifacts/*.whl
-        python -m twine upload --verbose ${SKIP_EXISTING_CMD} ${LIBRARY_NAME}-artifacts/*.tar.gz
+        python -m twine upload --verbose ${LIBRARY_NAME}-artifacts/*.whl
+        python -m twine upload --verbose ${LIBRARY_NAME}-artifacts/*.tar.gz
       env:
         TWINE_USERNAME: ${{ inputs.twine-username }}
         TWINE_PASSWORD: ${{ inputs.twine-token }}
         TWINE_REPOSITORY_URL: ${{ inputs.index-name }}
         LIBRARY_NAME: ${{ inputs.library-name }}
-        SKIP_EXISTING_CMD: ${{ steps.skip-existing.outputs.SKIP_EXISTING_CMD }}

--- a/doc/source/changelog/1518.maintenance.md
+++ b/doc/source/changelog/1518.maintenance.md
@@ -1,0 +1,1 @@
+Remove \`skip-existing\` input for release-pypi-private

--- a/release-pypi-private/action.yml
+++ b/release-pypi-private/action.yml
@@ -91,14 +91,6 @@ inputs:
     default: false
     type: boolean
 
-  skip-existing:
-    description: |
-      Continue uploading files if one already exists. Only valid when uploading
-      to PyPI. Other implementations may not support this.
-    required: false
-    default: true
-    type: boolean
-
   python-version:
     description: |
       Python version for installing and using `twine
@@ -135,6 +127,5 @@ runs:
         twine-token: ${{ inputs.twine-token }}
         python-version: ${{ inputs.python-version }}
         dry-run: ${{ inputs.dry-run }}
-        skip-existing: ${{ inputs.skip-existing }}
         use-trusted-publisher: ${{ inputs.use-trusted-publisher }}
         verify-tag-version: ${{ inputs.verify-tag-version }}


### PR DESCRIPTION
Closes #1515.

Given that the public release-* actions have been deprecated and the private PyPI did not support the option to begin with, I think it makes sense to just silently remove the option. That would resolve the ongoing issues and we don't have to worry about deprecation book keeping.