### PR TITLE
chore: remove reference to skip existing in other release actions

### DIFF
--- a/doc/source/changelog/1525.maintenance.md
+++ b/doc/source/changelog/1525.maintenance.md
@@ -1,0 +1,1 @@
+Remove reference to skip existing in other release actions

--- a/release-pypi-public/action.yml
+++ b/release-pypi-public/action.yml
@@ -105,14 +105,6 @@ inputs:
     default: false
     type: boolean
 
-  skip-existing:
-    description: |
-      Continue uploading files if one already exists. Only valid when uploading
-      to PyPI. Other implementations may not support this.
-    required: false
-    default: true
-    type: boolean
-
   python-version:
     description: |
       Python version for installing and using `twine

--- a/release-pypi-test/action.yml
+++ b/release-pypi-test/action.yml
@@ -113,14 +113,6 @@ inputs:
     default: '3.12'
     type: string
 
-  skip-existing:
-    description: |
-      Continue uploading files if one already exists. Only valid when uploading
-      to PyPI. Other implementations may not support this.
-    required: false
-    default: true
-    type: boolean
-
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
As the title states. Follow up to #1518.