### PR TITLE
feat: LFS support during checkout

### DIFF
--- a/build-library/action.yml
+++ b/build-library/action.yml
@@ -84,6 +84,16 @@ inputs:
     default: true
     type: boolean
 
+  checkout-lfs:
+    description: |
+      Whether to download Git LFS-tracked files during the checkout step.
+      Enable this when the repository stores package data files tracked with
+      Git LFS that must be included in the built sdist/wheel. Only applies
+      when ``checkout`` is ``true``. Default value is ``false``.
+    required: false
+    default: false
+    type: boolean
+
   validate-build:
     description: |
       Whether to validate the build process. If ``true``, the build process is
@@ -147,6 +157,7 @@ runs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+        lfs: ${{ inputs.checkout-lfs }}
 
     - name: "Set up Python ${{ inputs.python-version }}"
       if: ${{ inputs.skip-python-setup == 'false' }}

--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -113,6 +113,16 @@ inputs:
     default: true
     type: boolean
 
+  checkout-lfs:
+    description: |
+      Whether to download Git LFS-tracked files during the checkout step.
+      Enable this when the repository stores package data files tracked with
+      Git LFS that must be included in the built wheelhouse. Only applies
+      when ``checkout`` is ``true``. Default value is ``false``.
+    required: false
+    default: false
+    type: boolean
+
   working-directory:
      description: |
        Directory to execute this action. Useful for repositories containing
@@ -184,6 +194,7 @@ runs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+        lfs: ${{ inputs.checkout-lfs }}
 
     - name: "Set up Python ${{ inputs.python-version }}"
       if: ${{ inputs.skip-python-setup == 'false' }}

--- a/doc-build/action.yml
+++ b/doc-build/action.yml
@@ -138,6 +138,15 @@ inputs:
     required: false
     type: boolean
 
+  checkout-lfs:
+    description: |
+      Whether to download Git LFS-tracked files during the checkout step.
+      Enable this when the repository stores documentation assets tracked with
+      Git LFS. Only applies when ``checkout`` is ``true``. Default value is ``false``.
+    default: false
+    required: false
+    type: boolean
+
   check-links:
     description: |
       Whether to perform external link checks during the generation of
@@ -249,6 +258,7 @@ runs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+        lfs: ${{ inputs.checkout-lfs }}
       if: ${{ inputs.checkout == 'true' }}
 
     - name: "Set up Python ${{ inputs.python-version }}"

--- a/doc/source/changelog/1531.added.md
+++ b/doc/source/changelog/1531.added.md
@@ -1,0 +1,1 @@
+LFS support during checkout

--- a/doc/source/migrations/index.rst
+++ b/doc/source/migrations/index.rst
@@ -7,6 +7,19 @@ This guide provides information on new features, breaking changes, how to migrat
 from one version of the actions to another, and other upstream dependencies that
 have been updated.
 
+Version ``v11.1``
+-----------------
+
+**New Features:**
+
+- **Git LFS support during checkout:** The ``doc-build``, ``tests-pytest``,
+  ``build-library``, and ``build-wheelhouse`` actions now expose a new
+  ``checkout-lfs`` boolean input (default ``false``). When set to ``true``, the
+  checkout step downloads Git LFS-tracked files. Enable this input when the
+  repository stores files with Git LFS that must be materialized before the action runs.
+  The default preserves the previous behavior, so no changes are required for existing
+  workflows.
+
 Version ``v11``
 ---------------
 

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -89,6 +89,16 @@ inputs:
     required: false
     type: boolean
 
+  checkout-lfs:
+    description: |
+      Whether to download Git LFS-tracked files during the checkout step.
+      Enable this when the repository stores test fixtures tracked with Git LFS
+      (reference data, mesh files, binary result files). Only applies when
+      ``checkout`` is ``true``. Default value is ``false``.
+    default: false
+    required: false
+    type: boolean
+
   skip-install:
     description: |
       Skip installation process. This should be set to `false` when using poetry
@@ -159,6 +169,7 @@ runs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+        lfs: ${{ inputs.checkout-lfs }}
       if: ${{ inputs.checkout == 'true' }}
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1437.

This PR exposes a `checkout-lfs` input for some actions so that projects leveraging git LFS can use those actions without adding preliminary steps.

I handpicked actions where it makes sense to support this input for the following reasons:
- `doc-build`: documentation assets can be tracked through LFS.
- `tests-pytest`: large binary inputs for tests are natural LFS candidates.
- `build-library` and `build-wheelhouse`: `.dll` and `.so` files are distributed in some libraries, and those are also good candidates for LFS.

@ansys/pyansys-core, let me know if it makes sense for any other action to support this input.