### PR TITLE
fix: error message rendering in doc-deploy-changelog

### DIFF
--- a/doc-deploy-changelog/action.yml
+++ b/doc-deploy-changelog/action.yml
@@ -387,10 +387,7 @@ runs:
 
           if [ -n "$section_exists_err" ] && [[ "${IS_PRE_RELEASE}" == "false" ]]; then
             # Print error message on how to fix this
-            message="Your changelog file already contains section ${TAG_VERSION} in the \
-            ${UPDATE_BRANCH} branch. Please checkout ${UPDATE_BRANCH}, revert \
-            the commit named 'chore: updating CHANGELOG for v${TAG_VERSION}', and \
-            re-run the workflow."
+            message="Your changelog file already contains section ${TAG_VERSION} in the ${UPDATE_BRANCH} branch. Please checkout ${UPDATE_BRANCH}, revert the commit named 'chore: updating CHANGELOG for v${TAG_VERSION}', and re-run the workflow."
 
             echo -e "\033[1;91m[ERROR]: $message\033[0m"
             exit 1

--- a/doc/source/changelog/1536.fixed.md
+++ b/doc/source/changelog/1536.fixed.md
@@ -1,0 +1,1 @@
+Error message rendering in doc-deploy-changelog


### PR DESCRIPTION
As title says. I came across the message below during a release and it felt like an env variable was missing. The problem was just related to the space management.

<img width="1261" height="84" alt="image" src="https://github.com/user-attachments/assets/08268299-ca38-4777-a087-d8e1bfa37ac1" />


