### PR TITLE
chore: delay dependabot update to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "wednesday"
     cooldown:
       default-days: 7
@@ -56,7 +56,7 @@ updates:
       - "release-pypi-test"
       - "tests-pytest"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "wednesday"
     cooldown:
       default-days: 7
@@ -119,7 +119,7 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "wednesday"
     cooldown:
       default-days: 7 # semver-* options are not applicable for pre-commit

--- a/doc/source/changelog/1539.maintenance.md
+++ b/doc/source/changelog/1539.maintenance.md
@@ -1,0 +1,1 @@
+Delay dependabot update to monthly


### PR DESCRIPTION
In the context of migration, delaying updates in our actions / dependencies will help users to use our releases.

Not sur if the precommit ecosystem needs to also be aligned but...