### PR TITLE
refactor: use lockfile to generate wheelhouse

### DIFF
--- a/build-wheelhouse/action.yml
+++ b/build-wheelhouse/action.yml
@@ -467,6 +467,8 @@ runs:
         INSTALL_TARGET: ${{ steps.specific-target-requested.outputs.install_target }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         GITHUB_WORKSPACE: ${{ github.workspace }}
+        USE_UV_LOCKFILE: ${{ steps.auto-detect-uv-lockfile.outputs.USE_UV_LOCKFILE }}
+        TARGET: ${{ inputs.target }}
       run: |
         ${ACTIVATE_VENV}
         cd ${WORKING_DIRECTORY}
@@ -474,7 +476,14 @@ runs:
           poetry export --without-hashes --format=requirements.txt --output=wheel_reqs.txt
           pip wheel -w ${GITHUB_WORKSPACE}/wheelhouse -r wheel_reqs.txt
         else
-          python -m pip wheel "${INSTALL_TARGET}" -w ${GITHUB_WORKSPACE}/wheelhouse
+          if [[ "${USE_UV_LOCKFILE}" == 'true' ]]; then
+            EXPORT_OPTIONS="--format=requirements.txt --no-hashes --no-dev --no-emit-project"
+            EXPORT_OPTIONS+=$( [[ "${TARGET}" != '' ]] && echo " --extra ${TARGET}" || echo "" )
+            uv export $EXPORT_OPTIONS --output-file=wheel_reqs.txt
+            python -m pip wheel -w ${GITHUB_WORKSPACE}/wheelhouse -r wheel_reqs.txt
+          else
+            python -m pip wheel "${INSTALL_TARGET}" -w ${GITHUB_WORKSPACE}/wheelhouse
+          fi
         fi
 
     - name: "Compress the wheelhouse"

--- a/doc/source/changelog/1549.miscellaneous.md
+++ b/doc/source/changelog/1549.miscellaneous.md
@@ -1,0 +1,1 @@
+Use lockfile to generate wheelhouse


### PR DESCRIPTION
**I'm not sure if I already raised that point but given that I couldn't find any history in GitHub, I'm opening this PR as both a POC and discussion place.**

---

This PR changes consist in using the project lockfile when building the wheelhouse for `uv`-based projects. This was already done with `poetry` and I don't see a reason not to do the same with `uv`. 

Pros:
- Keeps the wheelhouse reproducible for `uv`-based projects.
- Solves an issue related to `pip` resolution when developers define their dependencies with wide ranges (or no ranges at all). Indeed, in some cases we could end up with a very old version of a package or not finding one at all due to how `pip` does his resolution. An example of such scenario can be found in [here](https://github.com/ansys/pyaedt-toolkits-common/actions/runs/34333466933/job/102407399853?pr=495).
- No resolution required since the uv lock file already contains one (so faster run)

Cons:
- If the lockfile stale or isn't aligned with the project metadata, things could go wrong. But in that case, we have another bigger problem :)